### PR TITLE
US1339, Fastre-route for ISIS interafce address family

### DIFF
--- a/docs/data-sources/router_isis_interface_address_family.md
+++ b/docs/data-sources/router_isis_interface_address_family.md
@@ -38,7 +38,9 @@ data "iosxr_router_isis_interface_address_family" "example" {
 ### Read-Only
 
 - `advertise_prefix_route_policy` (String) Filter routes based on a route policy
-- `fast_reroute_per_prefix_levels` (Attributes List) Enable EPCFRR LFA for one level only (see [below for nested schema](#nestedatt--fast_reroute_per_prefix_levels))
+- `fast_reroute_computation_per_prefix_computation` (Boolean) Prefix dependent computation
+- `fast_reroute_per_prefix` (Attributes List) Enable EPCFRR LFA for one level only (see [below for nested schema](#nestedatt--fast_reroute_per_prefix))
+- `fast_reroute_per_prefix_ti_lfa` (Boolean) Enable TI LFA computation
 - `id` (String) The path of the retrieved object.
 - `metric` (Number) Default metric
 - `metric_levels` (Attributes List) Set metric for one level only (see [below for nested schema](#nestedatt--metric_levels))
@@ -49,8 +51,8 @@ data "iosxr_router_isis_interface_address_family" "example" {
 - `prefix_sid_strict_spf_absolute` (Number) Specify the absolute value of Prefix Segement ID
 - `tag` (Number) Set interface tag
 
-<a id="nestedatt--fast_reroute_per_prefix_levels"></a>
-### Nested Schema for `fast_reroute_per_prefix_levels`
+<a id="nestedatt--fast_reroute_per_prefix"></a>
+### Nested Schema for `fast_reroute_per_prefix`
 
 Read-Only:
 

--- a/docs/resources/router_isis_interface_address_family.md
+++ b/docs/resources/router_isis_interface_address_family.md
@@ -14,11 +14,13 @@ This resource can manage the Router ISIS Interface Address Family configuration.
 
 ```terraform
 resource "iosxr_router_isis_interface_address_family" "example" {
-  process_id     = "P1"
-  interface_name = "GigabitEthernet0/0/0/1"
-  af_name        = "ipv4"
-  saf_name       = "unicast"
-  fast_reroute_per_prefix_levels = [
+  process_id                                      = "P1"
+  interface_name                                  = "GigabitEthernet0/0/0/1"
+  af_name                                         = "ipv4"
+  saf_name                                        = "unicast"
+  fast_reroute_computation_per_prefix_computation = true
+  fast_reroute_per_prefix_ti_lfa                  = true
+  fast_reroute_per_prefix = [
     {
       level_id = 1
       ti_lfa   = true
@@ -54,7 +56,9 @@ resource "iosxr_router_isis_interface_address_family" "example" {
 - `delete_mode` (String) Configure behavior when deleting/destroying the resource. Either delete the entire object (YANG container) being managed, or only delete the individual resource attributes configured explicitly and leave everything else as-is. Default value is `all`.
   - Choices: `all`, `attributes`
 - `device` (String) A device name from the provider configuration.
-- `fast_reroute_per_prefix_levels` (Attributes List) Enable EPCFRR LFA for one level only (see [below for nested schema](#nestedatt--fast_reroute_per_prefix_levels))
+- `fast_reroute_computation_per_prefix_computation` (Boolean) Prefix dependent computation
+- `fast_reroute_per_prefix` (Attributes List) Enable EPCFRR LFA for one level only (see [below for nested schema](#nestedatt--fast_reroute_per_prefix))
+- `fast_reroute_per_prefix_ti_lfa` (Boolean) Enable TI LFA computation
 - `metric` (Number) Default metric
   - Range: `1`-`16777214`
 - `metric_levels` (Attributes List) Set metric for one level only (see [below for nested schema](#nestedatt--metric_levels))
@@ -73,8 +77,8 @@ resource "iosxr_router_isis_interface_address_family" "example" {
 
 - `id` (String) The path of the object.
 
-<a id="nestedatt--fast_reroute_per_prefix_levels"></a>
-### Nested Schema for `fast_reroute_per_prefix_levels`
+<a id="nestedatt--fast_reroute_per_prefix"></a>
+### Nested Schema for `fast_reroute_per_prefix`
 
 Required:
 

--- a/examples/resources/iosxr_router_isis_interface_address_family/resource.tf
+++ b/examples/resources/iosxr_router_isis_interface_address_family/resource.tf
@@ -1,9 +1,11 @@
 resource "iosxr_router_isis_interface_address_family" "example" {
-  process_id     = "P1"
-  interface_name = "GigabitEthernet0/0/0/1"
-  af_name        = "ipv4"
-  saf_name       = "unicast"
-  fast_reroute_per_prefix_levels = [
+  process_id                                      = "P1"
+  interface_name                                  = "GigabitEthernet0/0/0/1"
+  af_name                                         = "ipv4"
+  saf_name                                        = "unicast"
+  fast_reroute_computation_per_prefix_computation = true
+  fast_reroute_per_prefix_ti_lfa                  = true
+  fast_reroute_per_prefix = [
     {
       level_id = 1
       ti_lfa   = true

--- a/gen/definitions/router_isis_interface_address_family.yaml
+++ b/gen/definitions/router_isis_interface_address_family.yaml
@@ -11,8 +11,22 @@ attributes:
     example: ipv4
   - yang_name: saf-name
     example: unicast
+  - yang_name: fast-reroute/computation/per-prefix-computation
+    example: true
+  - yang_name: fast-reroute/per-prefix/per-prefix/ti-lfa
+    tf_name: fast_reroute_per_prefix_ti_lfa
+    example: true
+
+  # - yang_name: fast-reroute/computation/levels/level
+  #   tf_name: fast_reroute_per_prefix
+  #   type: List
+  #   attributes:
+  #     - yang_name: level-id
+  #       id: true
+  #       example: 2
+
   - yang_name: fast-reroute/per-prefix/per-prefix/levels/level
-    tf_name: fast_reroute_per_prefix_levels
+    tf_name: fast_reroute_per_prefix
     type: List
     attributes:
       - yang_name: level-id

--- a/internal/provider/data_source_iosxr_router_isis_interface_address_family.go
+++ b/internal/provider/data_source_iosxr_router_isis_interface_address_family.go
@@ -78,7 +78,15 @@ func (d *RouterISISInterfaceAddressFamilyDataSource) Schema(ctx context.Context,
 				MarkdownDescription: "Sub address family name",
 				Required:            true,
 			},
-			"fast_reroute_per_prefix_levels": schema.ListNestedAttribute{
+			"fast_reroute_computation_per_prefix_computation": schema.BoolAttribute{
+				MarkdownDescription: "Prefix dependent computation",
+				Computed:            true,
+			},
+			"fast_reroute_per_prefix_ti_lfa": schema.BoolAttribute{
+				MarkdownDescription: "Enable TI LFA computation",
+				Computed:            true,
+			},
+			"fast_reroute_per_prefix": schema.ListNestedAttribute{
 				MarkdownDescription: "Enable EPCFRR LFA for one level only",
 				Computed:            true,
 				NestedObject: schema.NestedAttributeObject{

--- a/internal/provider/data_source_iosxr_router_isis_interface_address_family_test.go
+++ b/internal/provider/data_source_iosxr_router_isis_interface_address_family_test.go
@@ -27,8 +27,10 @@ import (
 
 func TestAccDataSourceIosxrRouterISISInterfaceAddressFamily(t *testing.T) {
 	var checks []resource.TestCheckFunc
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_isis_interface_address_family.test", "fast_reroute_per_prefix_levels.0.level_id", "1"))
-	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_isis_interface_address_family.test", "fast_reroute_per_prefix_levels.0.ti_lfa", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_isis_interface_address_family.test", "fast_reroute_computation_per_prefix_computation", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_isis_interface_address_family.test", "fast_reroute_per_prefix_ti_lfa", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_isis_interface_address_family.test", "fast_reroute_per_prefix.0.level_id", "1"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_isis_interface_address_family.test", "fast_reroute_per_prefix.0.ti_lfa", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_isis_interface_address_family.test", "tag", "100"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_isis_interface_address_family.test", "advertise_prefix_route_policy", "ROUTE_POLICY_1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_isis_interface_address_family.test", "metric", "500"))
@@ -64,7 +66,9 @@ func testAccDataSourceIosxrRouterISISInterfaceAddressFamilyConfig() string {
 	config += `	interface_name = "GigabitEthernet0/0/0/1"` + "\n"
 	config += `	af_name = "ipv4"` + "\n"
 	config += `	saf_name = "unicast"` + "\n"
-	config += `	fast_reroute_per_prefix_levels = [{` + "\n"
+	config += `	fast_reroute_computation_per_prefix_computation = true` + "\n"
+	config += `	fast_reroute_per_prefix_ti_lfa = true` + "\n"
+	config += `	fast_reroute_per_prefix = [{` + "\n"
 	config += `		level_id = 1` + "\n"
 	config += `		ti_lfa = true` + "\n"
 	config += `	}]` + "\n"

--- a/internal/provider/model_iosxr_router_isis_interface_address_family.go
+++ b/internal/provider/model_iosxr_router_isis_interface_address_family.go
@@ -31,44 +31,48 @@ import (
 )
 
 type RouterISISInterfaceAddressFamily struct {
-	Device                     types.String                                                 `tfsdk:"device"`
-	Id                         types.String                                                 `tfsdk:"id"`
-	DeleteMode                 types.String                                                 `tfsdk:"delete_mode"`
-	ProcessId                  types.String                                                 `tfsdk:"process_id"`
-	InterfaceName              types.String                                                 `tfsdk:"interface_name"`
-	AfName                     types.String                                                 `tfsdk:"af_name"`
-	SafName                    types.String                                                 `tfsdk:"saf_name"`
-	FastReroutePerPrefixLevels []RouterISISInterfaceAddressFamilyFastReroutePerPrefixLevels `tfsdk:"fast_reroute_per_prefix_levels"`
-	Tag                        types.Int64                                                  `tfsdk:"tag"`
-	PrefixSidAbsolute          types.Int64                                                  `tfsdk:"prefix_sid_absolute"`
-	PrefixSidNFlagClear        types.Bool                                                   `tfsdk:"prefix_sid_n_flag_clear"`
-	AdvertisePrefixRoutePolicy types.String                                                 `tfsdk:"advertise_prefix_route_policy"`
-	PrefixSidIndex             types.Int64                                                  `tfsdk:"prefix_sid_index"`
-	PrefixSidStrictSpfAbsolute types.Int64                                                  `tfsdk:"prefix_sid_strict_spf_absolute"`
-	Metric                     types.Int64                                                  `tfsdk:"metric"`
-	MetricMaximum              types.Bool                                                   `tfsdk:"metric_maximum"`
-	MetricLevels               []RouterISISInterfaceAddressFamilyMetricLevels               `tfsdk:"metric_levels"`
+	Device                                     types.String                                           `tfsdk:"device"`
+	Id                                         types.String                                           `tfsdk:"id"`
+	DeleteMode                                 types.String                                           `tfsdk:"delete_mode"`
+	ProcessId                                  types.String                                           `tfsdk:"process_id"`
+	InterfaceName                              types.String                                           `tfsdk:"interface_name"`
+	AfName                                     types.String                                           `tfsdk:"af_name"`
+	SafName                                    types.String                                           `tfsdk:"saf_name"`
+	FastRerouteComputationPerPrefixComputation types.Bool                                             `tfsdk:"fast_reroute_computation_per_prefix_computation"`
+	FastReroutePerPrefixTiLfa                  types.Bool                                             `tfsdk:"fast_reroute_per_prefix_ti_lfa"`
+	FastReroutePerPrefix                       []RouterISISInterfaceAddressFamilyFastReroutePerPrefix `tfsdk:"fast_reroute_per_prefix"`
+	Tag                                        types.Int64                                            `tfsdk:"tag"`
+	PrefixSidAbsolute                          types.Int64                                            `tfsdk:"prefix_sid_absolute"`
+	PrefixSidNFlagClear                        types.Bool                                             `tfsdk:"prefix_sid_n_flag_clear"`
+	AdvertisePrefixRoutePolicy                 types.String                                           `tfsdk:"advertise_prefix_route_policy"`
+	PrefixSidIndex                             types.Int64                                            `tfsdk:"prefix_sid_index"`
+	PrefixSidStrictSpfAbsolute                 types.Int64                                            `tfsdk:"prefix_sid_strict_spf_absolute"`
+	Metric                                     types.Int64                                            `tfsdk:"metric"`
+	MetricMaximum                              types.Bool                                             `tfsdk:"metric_maximum"`
+	MetricLevels                               []RouterISISInterfaceAddressFamilyMetricLevels         `tfsdk:"metric_levels"`
 }
 
 type RouterISISInterfaceAddressFamilyData struct {
-	Device                     types.String                                                 `tfsdk:"device"`
-	Id                         types.String                                                 `tfsdk:"id"`
-	ProcessId                  types.String                                                 `tfsdk:"process_id"`
-	InterfaceName              types.String                                                 `tfsdk:"interface_name"`
-	AfName                     types.String                                                 `tfsdk:"af_name"`
-	SafName                    types.String                                                 `tfsdk:"saf_name"`
-	FastReroutePerPrefixLevels []RouterISISInterfaceAddressFamilyFastReroutePerPrefixLevels `tfsdk:"fast_reroute_per_prefix_levels"`
-	Tag                        types.Int64                                                  `tfsdk:"tag"`
-	PrefixSidAbsolute          types.Int64                                                  `tfsdk:"prefix_sid_absolute"`
-	PrefixSidNFlagClear        types.Bool                                                   `tfsdk:"prefix_sid_n_flag_clear"`
-	AdvertisePrefixRoutePolicy types.String                                                 `tfsdk:"advertise_prefix_route_policy"`
-	PrefixSidIndex             types.Int64                                                  `tfsdk:"prefix_sid_index"`
-	PrefixSidStrictSpfAbsolute types.Int64                                                  `tfsdk:"prefix_sid_strict_spf_absolute"`
-	Metric                     types.Int64                                                  `tfsdk:"metric"`
-	MetricMaximum              types.Bool                                                   `tfsdk:"metric_maximum"`
-	MetricLevels               []RouterISISInterfaceAddressFamilyMetricLevels               `tfsdk:"metric_levels"`
+	Device                                     types.String                                           `tfsdk:"device"`
+	Id                                         types.String                                           `tfsdk:"id"`
+	ProcessId                                  types.String                                           `tfsdk:"process_id"`
+	InterfaceName                              types.String                                           `tfsdk:"interface_name"`
+	AfName                                     types.String                                           `tfsdk:"af_name"`
+	SafName                                    types.String                                           `tfsdk:"saf_name"`
+	FastRerouteComputationPerPrefixComputation types.Bool                                             `tfsdk:"fast_reroute_computation_per_prefix_computation"`
+	FastReroutePerPrefixTiLfa                  types.Bool                                             `tfsdk:"fast_reroute_per_prefix_ti_lfa"`
+	FastReroutePerPrefix                       []RouterISISInterfaceAddressFamilyFastReroutePerPrefix `tfsdk:"fast_reroute_per_prefix"`
+	Tag                                        types.Int64                                            `tfsdk:"tag"`
+	PrefixSidAbsolute                          types.Int64                                            `tfsdk:"prefix_sid_absolute"`
+	PrefixSidNFlagClear                        types.Bool                                             `tfsdk:"prefix_sid_n_flag_clear"`
+	AdvertisePrefixRoutePolicy                 types.String                                           `tfsdk:"advertise_prefix_route_policy"`
+	PrefixSidIndex                             types.Int64                                            `tfsdk:"prefix_sid_index"`
+	PrefixSidStrictSpfAbsolute                 types.Int64                                            `tfsdk:"prefix_sid_strict_spf_absolute"`
+	Metric                                     types.Int64                                            `tfsdk:"metric"`
+	MetricMaximum                              types.Bool                                             `tfsdk:"metric_maximum"`
+	MetricLevels                               []RouterISISInterfaceAddressFamilyMetricLevels         `tfsdk:"metric_levels"`
 }
-type RouterISISInterfaceAddressFamilyFastReroutePerPrefixLevels struct {
+type RouterISISInterfaceAddressFamilyFastReroutePerPrefix struct {
 	LevelId types.Int64 `tfsdk:"level_id"`
 	TiLfa   types.Bool  `tfsdk:"ti_lfa"`
 }
@@ -93,6 +97,16 @@ func (data RouterISISInterfaceAddressFamily) toBody(ctx context.Context) string 
 	}
 	if !data.SafName.IsNull() && !data.SafName.IsUnknown() {
 		body, _ = sjson.Set(body, "saf-name", data.SafName.ValueString())
+	}
+	if !data.FastRerouteComputationPerPrefixComputation.IsNull() && !data.FastRerouteComputationPerPrefixComputation.IsUnknown() {
+		if data.FastRerouteComputationPerPrefixComputation.ValueBool() {
+			body, _ = sjson.Set(body, "fast-reroute.computation.per-prefix-computation", map[string]string{})
+		}
+	}
+	if !data.FastReroutePerPrefixTiLfa.IsNull() && !data.FastReroutePerPrefixTiLfa.IsUnknown() {
+		if data.FastReroutePerPrefixTiLfa.ValueBool() {
+			body, _ = sjson.Set(body, "fast-reroute.per-prefix.per-prefix.ti-lfa", map[string]string{})
+		}
 	}
 	if !data.Tag.IsNull() && !data.Tag.IsUnknown() {
 		body, _ = sjson.Set(body, "tag.interface-tag", strconv.FormatInt(data.Tag.ValueInt64(), 10))
@@ -122,9 +136,9 @@ func (data RouterISISInterfaceAddressFamily) toBody(ctx context.Context) string 
 			body, _ = sjson.Set(body, "metric.maximum", map[string]string{})
 		}
 	}
-	if len(data.FastReroutePerPrefixLevels) > 0 {
+	if len(data.FastReroutePerPrefix) > 0 {
 		body, _ = sjson.Set(body, "fast-reroute.per-prefix.per-prefix.levels.level", []interface{}{})
-		for index, item := range data.FastReroutePerPrefixLevels {
+		for index, item := range data.FastReroutePerPrefix {
 			if !item.LevelId.IsNull() && !item.LevelId.IsUnknown() {
 				body, _ = sjson.Set(body, "fast-reroute.per-prefix.per-prefix.levels.level"+"."+strconv.Itoa(index)+"."+"level-id", strconv.FormatInt(item.LevelId.ValueInt64(), 10))
 			}
@@ -155,9 +169,27 @@ func (data RouterISISInterfaceAddressFamily) toBody(ctx context.Context) string 
 }
 
 func (data *RouterISISInterfaceAddressFamily) updateFromBody(ctx context.Context, res []byte) {
-	for i := range data.FastReroutePerPrefixLevels {
+	if value := gjson.GetBytes(res, "fast-reroute.computation.per-prefix-computation"); !data.FastRerouteComputationPerPrefixComputation.IsNull() {
+		if value.Exists() {
+			data.FastRerouteComputationPerPrefixComputation = types.BoolValue(true)
+		} else {
+			data.FastRerouteComputationPerPrefixComputation = types.BoolValue(false)
+		}
+	} else {
+		data.FastRerouteComputationPerPrefixComputation = types.BoolNull()
+	}
+	if value := gjson.GetBytes(res, "fast-reroute.per-prefix.per-prefix.ti-lfa"); !data.FastReroutePerPrefixTiLfa.IsNull() {
+		if value.Exists() {
+			data.FastReroutePerPrefixTiLfa = types.BoolValue(true)
+		} else {
+			data.FastReroutePerPrefixTiLfa = types.BoolValue(false)
+		}
+	} else {
+		data.FastReroutePerPrefixTiLfa = types.BoolNull()
+	}
+	for i := range data.FastReroutePerPrefix {
 		keys := [...]string{"level-id"}
-		keyValues := [...]string{strconv.FormatInt(data.FastReroutePerPrefixLevels[i].LevelId.ValueInt64(), 10)}
+		keyValues := [...]string{strconv.FormatInt(data.FastReroutePerPrefix[i].LevelId.ValueInt64(), 10)}
 
 		var r gjson.Result
 		gjson.GetBytes(res, "fast-reroute.per-prefix.per-prefix.levels.level").ForEach(
@@ -178,19 +210,19 @@ func (data *RouterISISInterfaceAddressFamily) updateFromBody(ctx context.Context
 				return true
 			},
 		)
-		if value := r.Get("level-id"); value.Exists() && !data.FastReroutePerPrefixLevels[i].LevelId.IsNull() {
-			data.FastReroutePerPrefixLevels[i].LevelId = types.Int64Value(value.Int())
+		if value := r.Get("level-id"); value.Exists() && !data.FastReroutePerPrefix[i].LevelId.IsNull() {
+			data.FastReroutePerPrefix[i].LevelId = types.Int64Value(value.Int())
 		} else {
-			data.FastReroutePerPrefixLevels[i].LevelId = types.Int64Null()
+			data.FastReroutePerPrefix[i].LevelId = types.Int64Null()
 		}
-		if value := r.Get("ti-lfa"); !data.FastReroutePerPrefixLevels[i].TiLfa.IsNull() {
+		if value := r.Get("ti-lfa"); !data.FastReroutePerPrefix[i].TiLfa.IsNull() {
 			if value.Exists() {
-				data.FastReroutePerPrefixLevels[i].TiLfa = types.BoolValue(true)
+				data.FastReroutePerPrefix[i].TiLfa = types.BoolValue(true)
 			} else {
-				data.FastReroutePerPrefixLevels[i].TiLfa = types.BoolValue(false)
+				data.FastReroutePerPrefix[i].TiLfa = types.BoolValue(false)
 			}
 		} else {
-			data.FastReroutePerPrefixLevels[i].TiLfa = types.BoolNull()
+			data.FastReroutePerPrefix[i].TiLfa = types.BoolNull()
 		}
 	}
 	if value := gjson.GetBytes(res, "tag.interface-tag"); value.Exists() && !data.Tag.IsNull() {
@@ -287,10 +319,20 @@ func (data *RouterISISInterfaceAddressFamily) updateFromBody(ctx context.Context
 }
 
 func (data *RouterISISInterfaceAddressFamilyData) fromBody(ctx context.Context, res []byte) {
+	if value := gjson.GetBytes(res, "fast-reroute.computation.per-prefix-computation"); value.Exists() {
+		data.FastRerouteComputationPerPrefixComputation = types.BoolValue(true)
+	} else {
+		data.FastRerouteComputationPerPrefixComputation = types.BoolValue(false)
+	}
+	if value := gjson.GetBytes(res, "fast-reroute.per-prefix.per-prefix.ti-lfa"); value.Exists() {
+		data.FastReroutePerPrefixTiLfa = types.BoolValue(true)
+	} else {
+		data.FastReroutePerPrefixTiLfa = types.BoolValue(false)
+	}
 	if value := gjson.GetBytes(res, "fast-reroute.per-prefix.per-prefix.levels.level"); value.Exists() {
-		data.FastReroutePerPrefixLevels = make([]RouterISISInterfaceAddressFamilyFastReroutePerPrefixLevels, 0)
+		data.FastReroutePerPrefix = make([]RouterISISInterfaceAddressFamilyFastReroutePerPrefix, 0)
 		value.ForEach(func(k, v gjson.Result) bool {
-			item := RouterISISInterfaceAddressFamilyFastReroutePerPrefixLevels{}
+			item := RouterISISInterfaceAddressFamilyFastReroutePerPrefix{}
 			if cValue := v.Get("level-id"); cValue.Exists() {
 				item.LevelId = types.Int64Value(cValue.Int())
 			}
@@ -299,7 +341,7 @@ func (data *RouterISISInterfaceAddressFamilyData) fromBody(ctx context.Context, 
 			} else {
 				item.TiLfa = types.BoolValue(false)
 			}
-			data.FastReroutePerPrefixLevels = append(data.FastReroutePerPrefixLevels, item)
+			data.FastReroutePerPrefix = append(data.FastReroutePerPrefix, item)
 			return true
 		})
 	}
@@ -354,16 +396,22 @@ func (data *RouterISISInterfaceAddressFamilyData) fromBody(ctx context.Context, 
 
 func (data *RouterISISInterfaceAddressFamily) getDeletedItems(ctx context.Context, state RouterISISInterfaceAddressFamily) []string {
 	deletedItems := make([]string, 0)
-	for i := range state.FastReroutePerPrefixLevels {
+	if !state.FastRerouteComputationPerPrefixComputation.IsNull() && data.FastRerouteComputationPerPrefixComputation.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/fast-reroute/computation/per-prefix-computation", state.getPath()))
+	}
+	if !state.FastReroutePerPrefixTiLfa.IsNull() && data.FastReroutePerPrefixTiLfa.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/fast-reroute/per-prefix/per-prefix/ti-lfa", state.getPath()))
+	}
+	for i := range state.FastReroutePerPrefix {
 		keys := [...]string{"level-id"}
-		stateKeyValues := [...]string{strconv.FormatInt(state.FastReroutePerPrefixLevels[i].LevelId.ValueInt64(), 10)}
+		stateKeyValues := [...]string{strconv.FormatInt(state.FastReroutePerPrefix[i].LevelId.ValueInt64(), 10)}
 		keyString := ""
 		for ki := range keys {
 			keyString += "[" + keys[ki] + "=" + stateKeyValues[ki] + "]"
 		}
 
 		emptyKeys := true
-		if !reflect.ValueOf(state.FastReroutePerPrefixLevels[i].LevelId.ValueInt64()).IsZero() {
+		if !reflect.ValueOf(state.FastReroutePerPrefix[i].LevelId.ValueInt64()).IsZero() {
 			emptyKeys = false
 		}
 		if emptyKeys {
@@ -371,13 +419,13 @@ func (data *RouterISISInterfaceAddressFamily) getDeletedItems(ctx context.Contex
 		}
 
 		found := false
-		for j := range data.FastReroutePerPrefixLevels {
+		for j := range data.FastReroutePerPrefix {
 			found = true
-			if state.FastReroutePerPrefixLevels[i].LevelId.ValueInt64() != data.FastReroutePerPrefixLevels[j].LevelId.ValueInt64() {
+			if state.FastReroutePerPrefix[i].LevelId.ValueInt64() != data.FastReroutePerPrefix[j].LevelId.ValueInt64() {
 				found = false
 			}
 			if found {
-				if !state.FastReroutePerPrefixLevels[i].TiLfa.IsNull() && data.FastReroutePerPrefixLevels[j].TiLfa.IsNull() {
+				if !state.FastReroutePerPrefix[i].TiLfa.IsNull() && data.FastReroutePerPrefix[j].TiLfa.IsNull() {
 					deletedItems = append(deletedItems, fmt.Sprintf("%v/fast-reroute/per-prefix/per-prefix/levels/level%v/ti-lfa", state.getPath(), keyString))
 				}
 				break
@@ -452,14 +500,20 @@ func (data *RouterISISInterfaceAddressFamily) getDeletedItems(ctx context.Contex
 
 func (data *RouterISISInterfaceAddressFamily) getEmptyLeafsDelete(ctx context.Context) []string {
 	emptyLeafsDelete := make([]string, 0)
-	for i := range data.FastReroutePerPrefixLevels {
+	if !data.FastRerouteComputationPerPrefixComputation.IsNull() && !data.FastRerouteComputationPerPrefixComputation.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/fast-reroute/computation/per-prefix-computation", data.getPath()))
+	}
+	if !data.FastReroutePerPrefixTiLfa.IsNull() && !data.FastReroutePerPrefixTiLfa.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/fast-reroute/per-prefix/per-prefix/ti-lfa", data.getPath()))
+	}
+	for i := range data.FastReroutePerPrefix {
 		keys := [...]string{"level-id"}
-		keyValues := [...]string{strconv.FormatInt(data.FastReroutePerPrefixLevels[i].LevelId.ValueInt64(), 10)}
+		keyValues := [...]string{strconv.FormatInt(data.FastReroutePerPrefix[i].LevelId.ValueInt64(), 10)}
 		keyString := ""
 		for ki := range keys {
 			keyString += "[" + keys[ki] + "=" + keyValues[ki] + "]"
 		}
-		if !data.FastReroutePerPrefixLevels[i].TiLfa.IsNull() && !data.FastReroutePerPrefixLevels[i].TiLfa.ValueBool() {
+		if !data.FastReroutePerPrefix[i].TiLfa.IsNull() && !data.FastReroutePerPrefix[i].TiLfa.ValueBool() {
 			emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/fast-reroute/per-prefix/per-prefix/levels/level%v/ti-lfa", data.getPath(), keyString))
 		}
 	}
@@ -485,9 +539,15 @@ func (data *RouterISISInterfaceAddressFamily) getEmptyLeafsDelete(ctx context.Co
 
 func (data *RouterISISInterfaceAddressFamily) getDeletePaths(ctx context.Context) []string {
 	var deletePaths []string
-	for i := range data.FastReroutePerPrefixLevels {
+	if !data.FastRerouteComputationPerPrefixComputation.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/fast-reroute/computation/per-prefix-computation", data.getPath()))
+	}
+	if !data.FastReroutePerPrefixTiLfa.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/fast-reroute/per-prefix/per-prefix/ti-lfa", data.getPath()))
+	}
+	for i := range data.FastReroutePerPrefix {
 		keys := [...]string{"level-id"}
-		keyValues := [...]string{strconv.FormatInt(data.FastReroutePerPrefixLevels[i].LevelId.ValueInt64(), 10)}
+		keyValues := [...]string{strconv.FormatInt(data.FastReroutePerPrefix[i].LevelId.ValueInt64(), 10)}
 
 		keyString := ""
 		for ki := range keys {

--- a/internal/provider/resource_iosxr_router_isis_interface_address_family.go
+++ b/internal/provider/resource_iosxr_router_isis_interface_address_family.go
@@ -114,7 +114,15 @@ func (r *RouterISISInterfaceAddressFamilyResource) Schema(ctx context.Context, r
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"fast_reroute_per_prefix_levels": schema.ListNestedAttribute{
+			"fast_reroute_computation_per_prefix_computation": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Prefix dependent computation").String,
+				Optional:            true,
+			},
+			"fast_reroute_per_prefix_ti_lfa": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Enable TI LFA computation").String,
+				Optional:            true,
+			},
+			"fast_reroute_per_prefix": schema.ListNestedAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Enable EPCFRR LFA for one level only").String,
 				Optional:            true,
 				NestedObject: schema.NestedAttributeObject{

--- a/internal/provider/resource_iosxr_router_isis_interface_address_family_test.go
+++ b/internal/provider/resource_iosxr_router_isis_interface_address_family_test.go
@@ -30,8 +30,10 @@ func TestAccIosxrRouterISISInterfaceAddressFamily(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_isis_interface_address_family.test", "af_name", "ipv4"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_isis_interface_address_family.test", "saf_name", "unicast"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_isis_interface_address_family.test", "fast_reroute_per_prefix_levels.0.level_id", "1"))
-	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_isis_interface_address_family.test", "fast_reroute_per_prefix_levels.0.ti_lfa", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_isis_interface_address_family.test", "fast_reroute_computation_per_prefix_computation", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_isis_interface_address_family.test", "fast_reroute_per_prefix_ti_lfa", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_isis_interface_address_family.test", "fast_reroute_per_prefix.0.level_id", "1"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_isis_interface_address_family.test", "fast_reroute_per_prefix.0.ti_lfa", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_isis_interface_address_family.test", "tag", "100"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_isis_interface_address_family.test", "advertise_prefix_route_policy", "ROUTE_POLICY_1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_isis_interface_address_family.test", "metric", "500"))
@@ -87,7 +89,9 @@ func testAccIosxrRouterISISInterfaceAddressFamilyConfig_all() string {
 	config += `	interface_name = "GigabitEthernet0/0/0/1"` + "\n"
 	config += `	af_name = "ipv4"` + "\n"
 	config += `	saf_name = "unicast"` + "\n"
-	config += `	fast_reroute_per_prefix_levels = [{` + "\n"
+	config += `	fast_reroute_computation_per_prefix_computation = true` + "\n"
+	config += `	fast_reroute_per_prefix_ti_lfa = true` + "\n"
+	config += `	fast_reroute_per_prefix = [{` + "\n"
 	config += `		level_id = 1` + "\n"
 	config += `		ti_lfa = true` + "\n"
 	config += `		}]` + "\n"


### PR DESCRIPTION
Unable to configure below attributes through terraform

```
  # - yang_name: fast-reroute/computation/levels/level
  #   tf_name: fast_reroute_per_prefix
  #   type: List
  #   attributes:
  #     - yang_name: level-id
  #       id: true
  #       example: 2
  ```