### PR TITLE
Add bfd/fast-detect to router_static_vrf

### DIFF
--- a/docs/data-sources/router_static_vrf_ipv4_multicast.md
+++ b/docs/data-sources/router_static_vrf_ipv4_multicast.md
@@ -61,6 +61,8 @@ Read-Only:
 Read-Only:
 
 - `address` (String) Forwarding router's address
+- `bfd_fast_detect_minimum_interval` (Number) Hello interval
+- `bfd_fast_detect_multiplier` (Number) Detect multiplier
 - `description` (String) description of the static route
 - `distance_metric` (Number) Distance metric for this route
 - `interface_name` (String) Forwarding interface

--- a/docs/data-sources/router_static_vrf_ipv4_unicast.md
+++ b/docs/data-sources/router_static_vrf_ipv4_unicast.md
@@ -61,6 +61,8 @@ Read-Only:
 Read-Only:
 
 - `address` (String) Forwarding router's address
+- `bfd_fast_detect_minimum_interval` (Number) Hello interval
+- `bfd_fast_detect_multiplier` (Number) Detect multiplier
 - `description` (String) description of the static route
 - `distance_metric` (Number) Distance metric for this route
 - `interface_name` (String) Forwarding interface

--- a/docs/data-sources/router_static_vrf_ipv6_multicast.md
+++ b/docs/data-sources/router_static_vrf_ipv6_multicast.md
@@ -114,6 +114,8 @@ Read-Only:
 Read-Only:
 
 - `address` (String) Forwarding router's address
+- `bfd_fast_detect_minimum_interval` (Number) Hello interval
+- `bfd_fast_detect_multiplier` (Number) Detect multiplier
 - `description` (String) description of the static route
 - `distance_metric` (Number) Distance metric for this route
 - `interface_name` (String) Forwarding interface

--- a/docs/data-sources/router_static_vrf_ipv6_unicast.md
+++ b/docs/data-sources/router_static_vrf_ipv6_unicast.md
@@ -61,6 +61,8 @@ Read-Only:
 Read-Only:
 
 - `address` (String) Forwarding router's address
+- `bfd_fast_detect_minimum_interval` (Number) Hello interval
+- `bfd_fast_detect_multiplier` (Number) Detect multiplier
 - `description` (String) description of the static route
 - `distance_metric` (Number) Distance metric for this route
 - `interface_name` (String) Forwarding interface

--- a/docs/resources/router_static_vrf_ipv4_multicast.md
+++ b/docs/resources/router_static_vrf_ipv4_multicast.md
@@ -29,13 +29,15 @@ resource "iosxr_router_static_vrf_ipv4_multicast" "example" {
   ]
   nexthop_interface_addresses = [
     {
-      interface_name  = "GigabitEthernet0/0/0/2"
-      address         = "11.11.11.1"
-      description     = "interface-description"
-      tag             = 103
-      distance_metric = 144
-      permanent       = true
-      metric          = 10
+      interface_name                   = "GigabitEthernet0/0/0/2"
+      address                          = "11.11.11.1"
+      description                      = "interface-description"
+      tag                              = 103
+      distance_metric                  = 144
+      permanent                        = true
+      metric                           = 10
+      bfd_fast_detect_minimum_interval = 100
+      bfd_fast_detect_multiplier       = 3
     }
   ]
   nexthop_addresses = [
@@ -141,6 +143,10 @@ Required:
 
 Optional:
 
+- `bfd_fast_detect_minimum_interval` (Number) Hello interval
+  - Range: `3`-`30000`
+- `bfd_fast_detect_multiplier` (Number) Detect multiplier
+  - Range: `1`-`10`
 - `description` (String) description of the static route
 - `distance_metric` (Number) Distance metric for this route
   - Range: `1`-`254`

--- a/docs/resources/router_static_vrf_ipv4_unicast.md
+++ b/docs/resources/router_static_vrf_ipv4_unicast.md
@@ -29,13 +29,15 @@ resource "iosxr_router_static_vrf_ipv4_unicast" "example" {
   ]
   nexthop_interface_addresses = [
     {
-      interface_name  = "GigabitEthernet0/0/0/2"
-      address         = "11.11.11.1"
-      description     = "interface-description"
-      tag             = 103
-      distance_metric = 144
-      permanent       = true
-      metric          = 10
+      interface_name                   = "GigabitEthernet0/0/0/2"
+      address                          = "11.11.11.1"
+      description                      = "interface-description"
+      tag                              = 103
+      distance_metric                  = 144
+      permanent                        = true
+      metric                           = 10
+      bfd_fast_detect_minimum_interval = 100
+      bfd_fast_detect_multiplier       = 3
     }
   ]
   nexthop_addresses = [
@@ -141,6 +143,10 @@ Required:
 
 Optional:
 
+- `bfd_fast_detect_minimum_interval` (Number) Hello interval
+  - Range: `3`-`30000`
+- `bfd_fast_detect_multiplier` (Number) Detect multiplier
+  - Range: `1`-`10`
 - `description` (String) description of the static route
 - `distance_metric` (Number) Distance metric for this route
   - Range: `1`-`254`

--- a/docs/resources/router_static_vrf_ipv6_multicast.md
+++ b/docs/resources/router_static_vrf_ipv6_multicast.md
@@ -63,13 +63,15 @@ resource "iosxr_router_static_vrf_ipv6_multicast" "example" {
       ]
       nexthop_interface_addresses = [
         {
-          interface_name  = "GigabitEthernet0/0/0/4"
-          address         = "2::2"
-          description     = "interface-description"
-          tag             = 103
-          distance_metric = 144
-          permanent       = true
-          metric          = 10
+          interface_name                   = "GigabitEthernet0/0/0/4"
+          address                          = "2::2"
+          description                      = "interface-description"
+          tag                              = 103
+          distance_metric                  = 144
+          permanent                        = true
+          metric                           = 10
+          bfd_fast_detect_minimum_interval = 100
+          bfd_fast_detect_multiplier       = 3
         }
       ]
       nexthop_addresses = [
@@ -215,6 +217,10 @@ Required:
 
 Optional:
 
+- `bfd_fast_detect_minimum_interval` (Number) Hello interval
+  - Range: `3`-`30000`
+- `bfd_fast_detect_multiplier` (Number) Detect multiplier
+  - Range: `1`-`10`
 - `description` (String) description of the static route
 - `distance_metric` (Number) Distance metric for this route
   - Range: `1`-`254`

--- a/docs/resources/router_static_vrf_ipv6_unicast.md
+++ b/docs/resources/router_static_vrf_ipv6_unicast.md
@@ -29,13 +29,15 @@ resource "iosxr_router_static_vrf_ipv6_unicast" "example" {
   ]
   nexthop_interface_addresses = [
     {
-      interface_name  = "GigabitEthernet0/0/0/2"
-      address         = "2::2"
-      description     = "interface-description"
-      tag             = 103
-      distance_metric = 144
-      permanent       = true
-      metric          = 10
+      interface_name                   = "GigabitEthernet0/0/0/2"
+      address                          = "2::2"
+      description                      = "interface-description"
+      tag                              = 103
+      distance_metric                  = 144
+      permanent                        = true
+      metric                           = 10
+      bfd_fast_detect_minimum_interval = 100
+      bfd_fast_detect_multiplier       = 3
     }
   ]
   nexthop_addresses = [
@@ -141,6 +143,10 @@ Required:
 
 Optional:
 
+- `bfd_fast_detect_minimum_interval` (Number) Hello interval
+  - Range: `3`-`30000`
+- `bfd_fast_detect_multiplier` (Number) Detect multiplier
+  - Range: `1`-`10`
 - `description` (String) description of the static route
 - `distance_metric` (Number) Distance metric for this route
   - Range: `1`-`254`

--- a/examples/resources/iosxr_router_static_vrf_ipv4_multicast/resource.tf
+++ b/examples/resources/iosxr_router_static_vrf_ipv4_multicast/resource.tf
@@ -14,13 +14,15 @@ resource "iosxr_router_static_vrf_ipv4_multicast" "example" {
   ]
   nexthop_interface_addresses = [
     {
-      interface_name  = "GigabitEthernet0/0/0/2"
-      address         = "11.11.11.1"
-      description     = "interface-description"
-      tag             = 103
-      distance_metric = 144
-      permanent       = true
-      metric          = 10
+      interface_name                   = "GigabitEthernet0/0/0/2"
+      address                          = "11.11.11.1"
+      description                      = "interface-description"
+      tag                              = 103
+      distance_metric                  = 144
+      permanent                        = true
+      metric                           = 10
+      bfd_fast_detect_minimum_interval = 100
+      bfd_fast_detect_multiplier       = 3
     }
   ]
   nexthop_addresses = [

--- a/examples/resources/iosxr_router_static_vrf_ipv4_unicast/resource.tf
+++ b/examples/resources/iosxr_router_static_vrf_ipv4_unicast/resource.tf
@@ -14,13 +14,15 @@ resource "iosxr_router_static_vrf_ipv4_unicast" "example" {
   ]
   nexthop_interface_addresses = [
     {
-      interface_name  = "GigabitEthernet0/0/0/2"
-      address         = "11.11.11.1"
-      description     = "interface-description"
-      tag             = 103
-      distance_metric = 144
-      permanent       = true
-      metric          = 10
+      interface_name                   = "GigabitEthernet0/0/0/2"
+      address                          = "11.11.11.1"
+      description                      = "interface-description"
+      tag                              = 103
+      distance_metric                  = 144
+      permanent                        = true
+      metric                           = 10
+      bfd_fast_detect_minimum_interval = 100
+      bfd_fast_detect_multiplier       = 3
     }
   ]
   nexthop_addresses = [

--- a/examples/resources/iosxr_router_static_vrf_ipv6_multicast/resource.tf
+++ b/examples/resources/iosxr_router_static_vrf_ipv6_multicast/resource.tf
@@ -48,13 +48,15 @@ resource "iosxr_router_static_vrf_ipv6_multicast" "example" {
       ]
       nexthop_interface_addresses = [
         {
-          interface_name  = "GigabitEthernet0/0/0/4"
-          address         = "2::2"
-          description     = "interface-description"
-          tag             = 103
-          distance_metric = 144
-          permanent       = true
-          metric          = 10
+          interface_name                   = "GigabitEthernet0/0/0/4"
+          address                          = "2::2"
+          description                      = "interface-description"
+          tag                              = 103
+          distance_metric                  = 144
+          permanent                        = true
+          metric                           = 10
+          bfd_fast_detect_minimum_interval = 100
+          bfd_fast_detect_multiplier       = 3
         }
       ]
       nexthop_addresses = [

--- a/examples/resources/iosxr_router_static_vrf_ipv6_unicast/resource.tf
+++ b/examples/resources/iosxr_router_static_vrf_ipv6_unicast/resource.tf
@@ -14,13 +14,15 @@ resource "iosxr_router_static_vrf_ipv6_unicast" "example" {
   ]
   nexthop_interface_addresses = [
     {
-      interface_name  = "GigabitEthernet0/0/0/2"
-      address         = "2::2"
-      description     = "interface-description"
-      tag             = 103
-      distance_metric = 144
-      permanent       = true
-      metric          = 10
+      interface_name                   = "GigabitEthernet0/0/0/2"
+      address                          = "2::2"
+      description                      = "interface-description"
+      tag                              = 103
+      distance_metric                  = 144
+      permanent                        = true
+      metric                           = 10
+      bfd_fast_detect_minimum_interval = 100
+      bfd_fast_detect_multiplier       = 3
     }
   ]
   nexthop_addresses = [

--- a/gen/definitions/router_static_vrf_ipv4_multicast.yaml
+++ b/gen/definitions/router_static_vrf_ipv4_multicast.yaml
@@ -52,6 +52,10 @@ attributes:
         exclude_test: true
       - yang_name: metric
         example: 10
+      - yang_name: bfd/fast-detect/minimum-interval
+        example: 100
+      - yang_name: bfd/fast-detect/multiplier
+        example: 3
   - yang_name: nexthop-addresses/nexthop-address
     tf_name: nexthop_addresses
     type: List

--- a/gen/definitions/router_static_vrf_ipv4_unicast.yaml
+++ b/gen/definitions/router_static_vrf_ipv4_unicast.yaml
@@ -52,6 +52,10 @@ attributes:
         exclude_test: true
       - yang_name: metric
         example: 10
+      - yang_name: bfd/fast-detect/minimum-interval
+        example: 100
+      - yang_name: bfd/fast-detect/multiplier
+        example: 3
   - yang_name: nexthop-addresses/nexthop-address
     tf_name: nexthop_addresses
     type: List

--- a/gen/definitions/router_static_vrf_ipv6_multicast.yaml
+++ b/gen/definitions/router_static_vrf_ipv6_multicast.yaml
@@ -122,6 +122,10 @@ attributes:
             exclude_test: true
           - yang_name: metric
             example: 10
+          - yang_name: bfd/fast-detect/minimum-interval
+            example: 100
+          - yang_name: bfd/fast-detect/multiplier
+            example: 3
       - yang_name: nexthop-addresses/nexthop-address
         tf_name: nexthop_addresses
         type: List

--- a/gen/definitions/router_static_vrf_ipv6_unicast.yaml
+++ b/gen/definitions/router_static_vrf_ipv6_unicast.yaml
@@ -52,6 +52,10 @@ attributes:
         exclude_test: true
       - yang_name: metric
         example: 10
+      - yang_name: bfd/fast-detect/minimum-interval
+        example: 100
+      - yang_name: bfd/fast-detect/multiplier
+        example: 3
   - yang_name: nexthop-addresses/nexthop-address
     tf_name: nexthop_addresses
     type: List

--- a/internal/provider/data_source_iosxr_router_static_vrf_ipv4_multicast.go
+++ b/internal/provider/data_source_iosxr_router_static_vrf_ipv4_multicast.go
@@ -147,6 +147,14 @@ func (d *RouterStaticVRFIPv4MulticastDataSource) Schema(ctx context.Context, req
 							MarkdownDescription: "Set metric for this route",
 							Computed:            true,
 						},
+						"bfd_fast_detect_minimum_interval": schema.Int64Attribute{
+							MarkdownDescription: "Hello interval",
+							Computed:            true,
+						},
+						"bfd_fast_detect_multiplier": schema.Int64Attribute{
+							MarkdownDescription: "Detect multiplier",
+							Computed:            true,
+						},
 					},
 				},
 			},

--- a/internal/provider/data_source_iosxr_router_static_vrf_ipv4_multicast_test.go
+++ b/internal/provider/data_source_iosxr_router_static_vrf_ipv4_multicast_test.go
@@ -40,6 +40,8 @@ func TestAccDataSourceIosxrRouterStaticVRFIPv4Multicast(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv4_multicast.test", "nexthop_interface_addresses.0.distance_metric", "144"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv4_multicast.test", "nexthop_interface_addresses.0.permanent", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv4_multicast.test", "nexthop_interface_addresses.0.metric", "10"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv4_multicast.test", "nexthop_interface_addresses.0.bfd_fast_detect_minimum_interval", "100"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv4_multicast.test", "nexthop_interface_addresses.0.bfd_fast_detect_multiplier", "3"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv4_multicast.test", "nexthop_addresses.0.address", "100.0.2.0"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv4_multicast.test", "nexthop_addresses.0.description", "ip-description"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv4_multicast.test", "nexthop_addresses.0.tag", "104"))
@@ -100,6 +102,8 @@ func testAccDataSourceIosxrRouterStaticVRFIPv4MulticastConfig() string {
 	config += `		distance_metric = 144` + "\n"
 	config += `		permanent = true` + "\n"
 	config += `		metric = 10` + "\n"
+	config += `		bfd_fast_detect_minimum_interval = 100` + "\n"
+	config += `		bfd_fast_detect_multiplier = 3` + "\n"
 	config += `	}]` + "\n"
 	config += `	nexthop_addresses = [{` + "\n"
 	config += `		address = "100.0.2.0"` + "\n"

--- a/internal/provider/data_source_iosxr_router_static_vrf_ipv4_unicast.go
+++ b/internal/provider/data_source_iosxr_router_static_vrf_ipv4_unicast.go
@@ -147,6 +147,14 @@ func (d *RouterStaticVRFIPv4UnicastDataSource) Schema(ctx context.Context, req d
 							MarkdownDescription: "Set metric for this route",
 							Computed:            true,
 						},
+						"bfd_fast_detect_minimum_interval": schema.Int64Attribute{
+							MarkdownDescription: "Hello interval",
+							Computed:            true,
+						},
+						"bfd_fast_detect_multiplier": schema.Int64Attribute{
+							MarkdownDescription: "Detect multiplier",
+							Computed:            true,
+						},
 					},
 				},
 			},

--- a/internal/provider/data_source_iosxr_router_static_vrf_ipv4_unicast_test.go
+++ b/internal/provider/data_source_iosxr_router_static_vrf_ipv4_unicast_test.go
@@ -40,6 +40,8 @@ func TestAccDataSourceIosxrRouterStaticVRFIPv4Unicast(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv4_unicast.test", "nexthop_interface_addresses.0.distance_metric", "144"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv4_unicast.test", "nexthop_interface_addresses.0.permanent", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv4_unicast.test", "nexthop_interface_addresses.0.metric", "10"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv4_unicast.test", "nexthop_interface_addresses.0.bfd_fast_detect_minimum_interval", "100"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv4_unicast.test", "nexthop_interface_addresses.0.bfd_fast_detect_multiplier", "3"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv4_unicast.test", "nexthop_addresses.0.address", "100.0.2.0"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv4_unicast.test", "nexthop_addresses.0.description", "ip-description"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv4_unicast.test", "nexthop_addresses.0.tag", "104"))
@@ -100,6 +102,8 @@ func testAccDataSourceIosxrRouterStaticVRFIPv4UnicastConfig() string {
 	config += `		distance_metric = 144` + "\n"
 	config += `		permanent = true` + "\n"
 	config += `		metric = 10` + "\n"
+	config += `		bfd_fast_detect_minimum_interval = 100` + "\n"
+	config += `		bfd_fast_detect_multiplier = 3` + "\n"
 	config += `	}]` + "\n"
 	config += `	nexthop_addresses = [{` + "\n"
 	config += `		address = "100.0.2.0"` + "\n"

--- a/internal/provider/data_source_iosxr_router_static_vrf_ipv6_multicast.go
+++ b/internal/provider/data_source_iosxr_router_static_vrf_ipv6_multicast.go
@@ -268,6 +268,14 @@ func (d *RouterStaticVRFIPv6MulticastDataSource) Schema(ctx context.Context, req
 										MarkdownDescription: "Set metric for this route",
 										Computed:            true,
 									},
+									"bfd_fast_detect_minimum_interval": schema.Int64Attribute{
+										MarkdownDescription: "Hello interval",
+										Computed:            true,
+									},
+									"bfd_fast_detect_multiplier": schema.Int64Attribute{
+										MarkdownDescription: "Detect multiplier",
+										Computed:            true,
+									},
 								},
 							},
 						},

--- a/internal/provider/data_source_iosxr_router_static_vrf_ipv6_multicast_test.go
+++ b/internal/provider/data_source_iosxr_router_static_vrf_ipv6_multicast_test.go
@@ -60,6 +60,8 @@ func TestAccDataSourceIosxrRouterStaticVRFIPv6Multicast(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv6_multicast.test", "vrfs.0.nexthop_interface_addresses.0.distance_metric", "144"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv6_multicast.test", "vrfs.0.nexthop_interface_addresses.0.permanent", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv6_multicast.test", "vrfs.0.nexthop_interface_addresses.0.metric", "10"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv6_multicast.test", "vrfs.0.nexthop_interface_addresses.0.bfd_fast_detect_minimum_interval", "100"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv6_multicast.test", "vrfs.0.nexthop_interface_addresses.0.bfd_fast_detect_multiplier", "3"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv6_multicast.test", "vrfs.0.nexthop_addresses.0.address", "3::3"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv6_multicast.test", "vrfs.0.nexthop_addresses.0.description", "ip-description"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv6_multicast.test", "vrfs.0.nexthop_addresses.0.tag", "104"))
@@ -127,6 +129,8 @@ func testAccDataSourceIosxrRouterStaticVRFIPv6MulticastConfig() string {
 	config += `			distance_metric = 144` + "\n"
 	config += `			permanent = true` + "\n"
 	config += `			metric = 10` + "\n"
+	config += `			bfd_fast_detect_minimum_interval = 100` + "\n"
+	config += `			bfd_fast_detect_multiplier = 3` + "\n"
 	config += `		}]` + "\n"
 	config += `		nexthop_addresses = [{` + "\n"
 	config += `			address = "3::3"` + "\n"

--- a/internal/provider/data_source_iosxr_router_static_vrf_ipv6_unicast.go
+++ b/internal/provider/data_source_iosxr_router_static_vrf_ipv6_unicast.go
@@ -147,6 +147,14 @@ func (d *RouterStaticVRFIPv6UnicastDataSource) Schema(ctx context.Context, req d
 							MarkdownDescription: "Set metric for this route",
 							Computed:            true,
 						},
+						"bfd_fast_detect_minimum_interval": schema.Int64Attribute{
+							MarkdownDescription: "Hello interval",
+							Computed:            true,
+						},
+						"bfd_fast_detect_multiplier": schema.Int64Attribute{
+							MarkdownDescription: "Detect multiplier",
+							Computed:            true,
+						},
 					},
 				},
 			},

--- a/internal/provider/data_source_iosxr_router_static_vrf_ipv6_unicast_test.go
+++ b/internal/provider/data_source_iosxr_router_static_vrf_ipv6_unicast_test.go
@@ -40,6 +40,8 @@ func TestAccDataSourceIosxrRouterStaticVRFIPv6Unicast(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv6_unicast.test", "nexthop_interface_addresses.0.distance_metric", "144"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv6_unicast.test", "nexthop_interface_addresses.0.permanent", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv6_unicast.test", "nexthop_interface_addresses.0.metric", "10"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv6_unicast.test", "nexthop_interface_addresses.0.bfd_fast_detect_minimum_interval", "100"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv6_unicast.test", "nexthop_interface_addresses.0.bfd_fast_detect_multiplier", "3"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv6_unicast.test", "nexthop_addresses.0.address", "3::3"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv6_unicast.test", "nexthop_addresses.0.description", "ip-description"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_router_static_vrf_ipv6_unicast.test", "nexthop_addresses.0.tag", "104"))
@@ -100,6 +102,8 @@ func testAccDataSourceIosxrRouterStaticVRFIPv6UnicastConfig() string {
 	config += `		distance_metric = 144` + "\n"
 	config += `		permanent = true` + "\n"
 	config += `		metric = 10` + "\n"
+	config += `		bfd_fast_detect_minimum_interval = 100` + "\n"
+	config += `		bfd_fast_detect_multiplier = 3` + "\n"
 	config += `	}]` + "\n"
 	config += `	nexthop_addresses = [{` + "\n"
 	config += `		address = "3::3"` + "\n"

--- a/internal/provider/model_iosxr_router_static_vrf_ipv4_multicast.go
+++ b/internal/provider/model_iosxr_router_static_vrf_ipv4_multicast.go
@@ -64,14 +64,16 @@ type RouterStaticVRFIPv4MulticastNexthopInterfaces struct {
 	Metric         types.Int64  `tfsdk:"metric"`
 }
 type RouterStaticVRFIPv4MulticastNexthopInterfaceAddresses struct {
-	InterfaceName  types.String `tfsdk:"interface_name"`
-	Address        types.String `tfsdk:"address"`
-	Description    types.String `tfsdk:"description"`
-	Tag            types.Int64  `tfsdk:"tag"`
-	DistanceMetric types.Int64  `tfsdk:"distance_metric"`
-	Permanent      types.Bool   `tfsdk:"permanent"`
-	Track          types.String `tfsdk:"track"`
-	Metric         types.Int64  `tfsdk:"metric"`
+	InterfaceName                types.String `tfsdk:"interface_name"`
+	Address                      types.String `tfsdk:"address"`
+	Description                  types.String `tfsdk:"description"`
+	Tag                          types.Int64  `tfsdk:"tag"`
+	DistanceMetric               types.Int64  `tfsdk:"distance_metric"`
+	Permanent                    types.Bool   `tfsdk:"permanent"`
+	Track                        types.String `tfsdk:"track"`
+	Metric                       types.Int64  `tfsdk:"metric"`
+	BfdFastDetectMinimumInterval types.Int64  `tfsdk:"bfd_fast_detect_minimum_interval"`
+	BfdFastDetectMultiplier      types.Int64  `tfsdk:"bfd_fast_detect_multiplier"`
 }
 type RouterStaticVRFIPv4MulticastNexthopAddresses struct {
 	Address        types.String `tfsdk:"address"`
@@ -189,6 +191,12 @@ func (data RouterStaticVRFIPv4Multicast) toBody(ctx context.Context) string {
 			}
 			if !item.Metric.IsNull() && !item.Metric.IsUnknown() {
 				body, _ = sjson.Set(body, "nexthop-interface-addresses.nexthop-interface-address"+"."+strconv.Itoa(index)+"."+"metric", strconv.FormatInt(item.Metric.ValueInt64(), 10))
+			}
+			if !item.BfdFastDetectMinimumInterval.IsNull() && !item.BfdFastDetectMinimumInterval.IsUnknown() {
+				body, _ = sjson.Set(body, "nexthop-interface-addresses.nexthop-interface-address"+"."+strconv.Itoa(index)+"."+"bfd.fast-detect.minimum-interval", strconv.FormatInt(item.BfdFastDetectMinimumInterval.ValueInt64(), 10))
+			}
+			if !item.BfdFastDetectMultiplier.IsNull() && !item.BfdFastDetectMultiplier.IsUnknown() {
+				body, _ = sjson.Set(body, "nexthop-interface-addresses.nexthop-interface-address"+"."+strconv.Itoa(index)+"."+"bfd.fast-detect.multiplier", strconv.FormatInt(item.BfdFastDetectMultiplier.ValueInt64(), 10))
 			}
 		}
 	}
@@ -448,6 +456,16 @@ func (data *RouterStaticVRFIPv4Multicast) updateFromBody(ctx context.Context, re
 			data.NexthopInterfaceAddresses[i].Metric = types.Int64Value(value.Int())
 		} else {
 			data.NexthopInterfaceAddresses[i].Metric = types.Int64Null()
+		}
+		if value := r.Get("bfd.fast-detect.minimum-interval"); value.Exists() && !data.NexthopInterfaceAddresses[i].BfdFastDetectMinimumInterval.IsNull() {
+			data.NexthopInterfaceAddresses[i].BfdFastDetectMinimumInterval = types.Int64Value(value.Int())
+		} else {
+			data.NexthopInterfaceAddresses[i].BfdFastDetectMinimumInterval = types.Int64Null()
+		}
+		if value := r.Get("bfd.fast-detect.multiplier"); value.Exists() && !data.NexthopInterfaceAddresses[i].BfdFastDetectMultiplier.IsNull() {
+			data.NexthopInterfaceAddresses[i].BfdFastDetectMultiplier = types.Int64Value(value.Int())
+		} else {
+			data.NexthopInterfaceAddresses[i].BfdFastDetectMultiplier = types.Int64Null()
 		}
 	}
 	for i := range data.NexthopAddresses {
@@ -800,6 +818,12 @@ func (data *RouterStaticVRFIPv4Multicast) fromBody(ctx context.Context, res []by
 			if cValue := v.Get("metric"); cValue.Exists() {
 				item.Metric = types.Int64Value(cValue.Int())
 			}
+			if cValue := v.Get("bfd.fast-detect.minimum-interval"); cValue.Exists() {
+				item.BfdFastDetectMinimumInterval = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("bfd.fast-detect.multiplier"); cValue.Exists() {
+				item.BfdFastDetectMultiplier = types.Int64Value(cValue.Int())
+			}
 			data.NexthopInterfaceAddresses = append(data.NexthopInterfaceAddresses, item)
 			return true
 		})
@@ -1005,6 +1029,12 @@ func (data *RouterStaticVRFIPv4MulticastData) fromBody(ctx context.Context, res 
 			}
 			if cValue := v.Get("metric"); cValue.Exists() {
 				item.Metric = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("bfd.fast-detect.minimum-interval"); cValue.Exists() {
+				item.BfdFastDetectMinimumInterval = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("bfd.fast-detect.multiplier"); cValue.Exists() {
+				item.BfdFastDetectMultiplier = types.Int64Value(cValue.Int())
 			}
 			data.NexthopInterfaceAddresses = append(data.NexthopInterfaceAddresses, item)
 			return true
@@ -1246,6 +1276,12 @@ func (data *RouterStaticVRFIPv4Multicast) getDeletedItems(ctx context.Context, s
 				}
 				if !state.NexthopInterfaceAddresses[i].Metric.IsNull() && data.NexthopInterfaceAddresses[j].Metric.IsNull() {
 					deletedItems = append(deletedItems, fmt.Sprintf("%v/nexthop-interface-addresses/nexthop-interface-address%v/metric", state.getPath(), keyString))
+				}
+				if !state.NexthopInterfaceAddresses[i].BfdFastDetectMinimumInterval.IsNull() && data.NexthopInterfaceAddresses[j].BfdFastDetectMinimumInterval.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/nexthop-interface-addresses/nexthop-interface-address%v/bfd/fast-detect/minimum-interval", state.getPath(), keyString))
+				}
+				if !state.NexthopInterfaceAddresses[i].BfdFastDetectMultiplier.IsNull() && data.NexthopInterfaceAddresses[j].BfdFastDetectMultiplier.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/nexthop-interface-addresses/nexthop-interface-address%v/bfd/fast-detect/multiplier", state.getPath(), keyString))
 				}
 				break
 			}

--- a/internal/provider/model_iosxr_router_static_vrf_ipv4_unicast.go
+++ b/internal/provider/model_iosxr_router_static_vrf_ipv4_unicast.go
@@ -64,14 +64,16 @@ type RouterStaticVRFIPv4UnicastNexthopInterfaces struct {
 	Metric         types.Int64  `tfsdk:"metric"`
 }
 type RouterStaticVRFIPv4UnicastNexthopInterfaceAddresses struct {
-	InterfaceName  types.String `tfsdk:"interface_name"`
-	Address        types.String `tfsdk:"address"`
-	Description    types.String `tfsdk:"description"`
-	Tag            types.Int64  `tfsdk:"tag"`
-	DistanceMetric types.Int64  `tfsdk:"distance_metric"`
-	Permanent      types.Bool   `tfsdk:"permanent"`
-	Track          types.String `tfsdk:"track"`
-	Metric         types.Int64  `tfsdk:"metric"`
+	InterfaceName                types.String `tfsdk:"interface_name"`
+	Address                      types.String `tfsdk:"address"`
+	Description                  types.String `tfsdk:"description"`
+	Tag                          types.Int64  `tfsdk:"tag"`
+	DistanceMetric               types.Int64  `tfsdk:"distance_metric"`
+	Permanent                    types.Bool   `tfsdk:"permanent"`
+	Track                        types.String `tfsdk:"track"`
+	Metric                       types.Int64  `tfsdk:"metric"`
+	BfdFastDetectMinimumInterval types.Int64  `tfsdk:"bfd_fast_detect_minimum_interval"`
+	BfdFastDetectMultiplier      types.Int64  `tfsdk:"bfd_fast_detect_multiplier"`
 }
 type RouterStaticVRFIPv4UnicastNexthopAddresses struct {
 	Address        types.String `tfsdk:"address"`
@@ -189,6 +191,12 @@ func (data RouterStaticVRFIPv4Unicast) toBody(ctx context.Context) string {
 			}
 			if !item.Metric.IsNull() && !item.Metric.IsUnknown() {
 				body, _ = sjson.Set(body, "nexthop-interface-addresses.nexthop-interface-address"+"."+strconv.Itoa(index)+"."+"metric", strconv.FormatInt(item.Metric.ValueInt64(), 10))
+			}
+			if !item.BfdFastDetectMinimumInterval.IsNull() && !item.BfdFastDetectMinimumInterval.IsUnknown() {
+				body, _ = sjson.Set(body, "nexthop-interface-addresses.nexthop-interface-address"+"."+strconv.Itoa(index)+"."+"bfd.fast-detect.minimum-interval", strconv.FormatInt(item.BfdFastDetectMinimumInterval.ValueInt64(), 10))
+			}
+			if !item.BfdFastDetectMultiplier.IsNull() && !item.BfdFastDetectMultiplier.IsUnknown() {
+				body, _ = sjson.Set(body, "nexthop-interface-addresses.nexthop-interface-address"+"."+strconv.Itoa(index)+"."+"bfd.fast-detect.multiplier", strconv.FormatInt(item.BfdFastDetectMultiplier.ValueInt64(), 10))
 			}
 		}
 	}
@@ -448,6 +456,16 @@ func (data *RouterStaticVRFIPv4Unicast) updateFromBody(ctx context.Context, res 
 			data.NexthopInterfaceAddresses[i].Metric = types.Int64Value(value.Int())
 		} else {
 			data.NexthopInterfaceAddresses[i].Metric = types.Int64Null()
+		}
+		if value := r.Get("bfd.fast-detect.minimum-interval"); value.Exists() && !data.NexthopInterfaceAddresses[i].BfdFastDetectMinimumInterval.IsNull() {
+			data.NexthopInterfaceAddresses[i].BfdFastDetectMinimumInterval = types.Int64Value(value.Int())
+		} else {
+			data.NexthopInterfaceAddresses[i].BfdFastDetectMinimumInterval = types.Int64Null()
+		}
+		if value := r.Get("bfd.fast-detect.multiplier"); value.Exists() && !data.NexthopInterfaceAddresses[i].BfdFastDetectMultiplier.IsNull() {
+			data.NexthopInterfaceAddresses[i].BfdFastDetectMultiplier = types.Int64Value(value.Int())
+		} else {
+			data.NexthopInterfaceAddresses[i].BfdFastDetectMultiplier = types.Int64Null()
 		}
 	}
 	for i := range data.NexthopAddresses {
@@ -800,6 +818,12 @@ func (data *RouterStaticVRFIPv4Unicast) fromBody(ctx context.Context, res []byte
 			if cValue := v.Get("metric"); cValue.Exists() {
 				item.Metric = types.Int64Value(cValue.Int())
 			}
+			if cValue := v.Get("bfd.fast-detect.minimum-interval"); cValue.Exists() {
+				item.BfdFastDetectMinimumInterval = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("bfd.fast-detect.multiplier"); cValue.Exists() {
+				item.BfdFastDetectMultiplier = types.Int64Value(cValue.Int())
+			}
 			data.NexthopInterfaceAddresses = append(data.NexthopInterfaceAddresses, item)
 			return true
 		})
@@ -1005,6 +1029,12 @@ func (data *RouterStaticVRFIPv4UnicastData) fromBody(ctx context.Context, res []
 			}
 			if cValue := v.Get("metric"); cValue.Exists() {
 				item.Metric = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("bfd.fast-detect.minimum-interval"); cValue.Exists() {
+				item.BfdFastDetectMinimumInterval = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("bfd.fast-detect.multiplier"); cValue.Exists() {
+				item.BfdFastDetectMultiplier = types.Int64Value(cValue.Int())
 			}
 			data.NexthopInterfaceAddresses = append(data.NexthopInterfaceAddresses, item)
 			return true
@@ -1246,6 +1276,12 @@ func (data *RouterStaticVRFIPv4Unicast) getDeletedItems(ctx context.Context, sta
 				}
 				if !state.NexthopInterfaceAddresses[i].Metric.IsNull() && data.NexthopInterfaceAddresses[j].Metric.IsNull() {
 					deletedItems = append(deletedItems, fmt.Sprintf("%v/nexthop-interface-addresses/nexthop-interface-address%v/metric", state.getPath(), keyString))
+				}
+				if !state.NexthopInterfaceAddresses[i].BfdFastDetectMinimumInterval.IsNull() && data.NexthopInterfaceAddresses[j].BfdFastDetectMinimumInterval.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/nexthop-interface-addresses/nexthop-interface-address%v/bfd/fast-detect/minimum-interval", state.getPath(), keyString))
+				}
+				if !state.NexthopInterfaceAddresses[i].BfdFastDetectMultiplier.IsNull() && data.NexthopInterfaceAddresses[j].BfdFastDetectMultiplier.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/nexthop-interface-addresses/nexthop-interface-address%v/bfd/fast-detect/multiplier", state.getPath(), keyString))
 				}
 				break
 			}

--- a/internal/provider/model_iosxr_router_static_vrf_ipv6_multicast.go
+++ b/internal/provider/model_iosxr_router_static_vrf_ipv6_multicast.go
@@ -98,14 +98,16 @@ type RouterStaticVRFIPv6MulticastVrfsNexthopInterfaces struct {
 	Metric         types.Int64  `tfsdk:"metric"`
 }
 type RouterStaticVRFIPv6MulticastVrfsNexthopInterfaceAddresses struct {
-	InterfaceName  types.String `tfsdk:"interface_name"`
-	Address        types.String `tfsdk:"address"`
-	Description    types.String `tfsdk:"description"`
-	Tag            types.Int64  `tfsdk:"tag"`
-	DistanceMetric types.Int64  `tfsdk:"distance_metric"`
-	Permanent      types.Bool   `tfsdk:"permanent"`
-	Track          types.String `tfsdk:"track"`
-	Metric         types.Int64  `tfsdk:"metric"`
+	InterfaceName                types.String `tfsdk:"interface_name"`
+	Address                      types.String `tfsdk:"address"`
+	Description                  types.String `tfsdk:"description"`
+	Tag                          types.Int64  `tfsdk:"tag"`
+	DistanceMetric               types.Int64  `tfsdk:"distance_metric"`
+	Permanent                    types.Bool   `tfsdk:"permanent"`
+	Track                        types.String `tfsdk:"track"`
+	Metric                       types.Int64  `tfsdk:"metric"`
+	BfdFastDetectMinimumInterval types.Int64  `tfsdk:"bfd_fast_detect_minimum_interval"`
+	BfdFastDetectMultiplier      types.Int64  `tfsdk:"bfd_fast_detect_multiplier"`
 }
 type RouterStaticVRFIPv6MulticastVrfsNexthopAddresses struct {
 	Address        types.String `tfsdk:"address"`
@@ -282,6 +284,12 @@ func (data RouterStaticVRFIPv6Multicast) toBody(ctx context.Context) string {
 					}
 					if !citem.Metric.IsNull() && !citem.Metric.IsUnknown() {
 						body, _ = sjson.Set(body, "vrfs.vrf"+"."+strconv.Itoa(index)+"."+"nexthop-interface-addresses.nexthop-interface-address"+"."+strconv.Itoa(cindex)+"."+"metric", strconv.FormatInt(citem.Metric.ValueInt64(), 10))
+					}
+					if !citem.BfdFastDetectMinimumInterval.IsNull() && !citem.BfdFastDetectMinimumInterval.IsUnknown() {
+						body, _ = sjson.Set(body, "vrfs.vrf"+"."+strconv.Itoa(index)+"."+"nexthop-interface-addresses.nexthop-interface-address"+"."+strconv.Itoa(cindex)+"."+"bfd.fast-detect.minimum-interval", strconv.FormatInt(citem.BfdFastDetectMinimumInterval.ValueInt64(), 10))
+					}
+					if !citem.BfdFastDetectMultiplier.IsNull() && !citem.BfdFastDetectMultiplier.IsUnknown() {
+						body, _ = sjson.Set(body, "vrfs.vrf"+"."+strconv.Itoa(index)+"."+"nexthop-interface-addresses.nexthop-interface-address"+"."+strconv.Itoa(cindex)+"."+"bfd.fast-detect.multiplier", strconv.FormatInt(citem.BfdFastDetectMultiplier.ValueInt64(), 10))
 					}
 				}
 			}
@@ -671,6 +679,16 @@ func (data *RouterStaticVRFIPv6Multicast) updateFromBody(ctx context.Context, re
 			} else {
 				data.Vrfs[i].NexthopInterfaceAddresses[ci].Metric = types.Int64Null()
 			}
+			if value := cr.Get("bfd.fast-detect.minimum-interval"); value.Exists() && !data.Vrfs[i].NexthopInterfaceAddresses[ci].BfdFastDetectMinimumInterval.IsNull() {
+				data.Vrfs[i].NexthopInterfaceAddresses[ci].BfdFastDetectMinimumInterval = types.Int64Value(value.Int())
+			} else {
+				data.Vrfs[i].NexthopInterfaceAddresses[ci].BfdFastDetectMinimumInterval = types.Int64Null()
+			}
+			if value := cr.Get("bfd.fast-detect.multiplier"); value.Exists() && !data.Vrfs[i].NexthopInterfaceAddresses[ci].BfdFastDetectMultiplier.IsNull() {
+				data.Vrfs[i].NexthopInterfaceAddresses[ci].BfdFastDetectMultiplier = types.Int64Value(value.Int())
+			} else {
+				data.Vrfs[i].NexthopInterfaceAddresses[ci].BfdFastDetectMultiplier = types.Int64Null()
+			}
 		}
 		for ci := range data.Vrfs[i].NexthopAddresses {
 			keys := [...]string{"address"}
@@ -903,6 +921,12 @@ func (data *RouterStaticVRFIPv6Multicast) fromBody(ctx context.Context, res []by
 					if ccValue := cv.Get("metric"); ccValue.Exists() {
 						cItem.Metric = types.Int64Value(ccValue.Int())
 					}
+					if ccValue := cv.Get("bfd.fast-detect.minimum-interval"); ccValue.Exists() {
+						cItem.BfdFastDetectMinimumInterval = types.Int64Value(ccValue.Int())
+					}
+					if ccValue := cv.Get("bfd.fast-detect.multiplier"); ccValue.Exists() {
+						cItem.BfdFastDetectMultiplier = types.Int64Value(ccValue.Int())
+					}
 					item.NexthopInterfaceAddresses = append(item.NexthopInterfaceAddresses, cItem)
 					return true
 				})
@@ -1108,6 +1132,12 @@ func (data *RouterStaticVRFIPv6MulticastData) fromBody(ctx context.Context, res 
 					}
 					if ccValue := cv.Get("metric"); ccValue.Exists() {
 						cItem.Metric = types.Int64Value(ccValue.Int())
+					}
+					if ccValue := cv.Get("bfd.fast-detect.minimum-interval"); ccValue.Exists() {
+						cItem.BfdFastDetectMinimumInterval = types.Int64Value(ccValue.Int())
+					}
+					if ccValue := cv.Get("bfd.fast-detect.multiplier"); ccValue.Exists() {
+						cItem.BfdFastDetectMultiplier = types.Int64Value(ccValue.Int())
 					}
 					item.NexthopInterfaceAddresses = append(item.NexthopInterfaceAddresses, cItem)
 					return true
@@ -1419,6 +1449,12 @@ func (data *RouterStaticVRFIPv6Multicast) getDeletedItems(ctx context.Context, s
 							}
 							if !state.Vrfs[i].NexthopInterfaceAddresses[ci].Metric.IsNull() && data.Vrfs[j].NexthopInterfaceAddresses[cj].Metric.IsNull() {
 								deletedItems = append(deletedItems, fmt.Sprintf("%v/vrfs/vrf%v/nexthop-interface-addresses/nexthop-interface-address%v/metric", state.getPath(), keyString, ckeyString))
+							}
+							if !state.Vrfs[i].NexthopInterfaceAddresses[ci].BfdFastDetectMinimumInterval.IsNull() && data.Vrfs[j].NexthopInterfaceAddresses[cj].BfdFastDetectMinimumInterval.IsNull() {
+								deletedItems = append(deletedItems, fmt.Sprintf("%v/vrfs/vrf%v/nexthop-interface-addresses/nexthop-interface-address%v/bfd/fast-detect/minimum-interval", state.getPath(), keyString, ckeyString))
+							}
+							if !state.Vrfs[i].NexthopInterfaceAddresses[ci].BfdFastDetectMultiplier.IsNull() && data.Vrfs[j].NexthopInterfaceAddresses[cj].BfdFastDetectMultiplier.IsNull() {
+								deletedItems = append(deletedItems, fmt.Sprintf("%v/vrfs/vrf%v/nexthop-interface-addresses/nexthop-interface-address%v/bfd/fast-detect/multiplier", state.getPath(), keyString, ckeyString))
 							}
 							break
 						}

--- a/internal/provider/model_iosxr_router_static_vrf_ipv6_unicast.go
+++ b/internal/provider/model_iosxr_router_static_vrf_ipv6_unicast.go
@@ -64,14 +64,16 @@ type RouterStaticVRFIPv6UnicastNexthopInterfaces struct {
 	Metric         types.Int64  `tfsdk:"metric"`
 }
 type RouterStaticVRFIPv6UnicastNexthopInterfaceAddresses struct {
-	InterfaceName  types.String `tfsdk:"interface_name"`
-	Address        types.String `tfsdk:"address"`
-	Description    types.String `tfsdk:"description"`
-	Tag            types.Int64  `tfsdk:"tag"`
-	DistanceMetric types.Int64  `tfsdk:"distance_metric"`
-	Permanent      types.Bool   `tfsdk:"permanent"`
-	Track          types.String `tfsdk:"track"`
-	Metric         types.Int64  `tfsdk:"metric"`
+	InterfaceName                types.String `tfsdk:"interface_name"`
+	Address                      types.String `tfsdk:"address"`
+	Description                  types.String `tfsdk:"description"`
+	Tag                          types.Int64  `tfsdk:"tag"`
+	DistanceMetric               types.Int64  `tfsdk:"distance_metric"`
+	Permanent                    types.Bool   `tfsdk:"permanent"`
+	Track                        types.String `tfsdk:"track"`
+	Metric                       types.Int64  `tfsdk:"metric"`
+	BfdFastDetectMinimumInterval types.Int64  `tfsdk:"bfd_fast_detect_minimum_interval"`
+	BfdFastDetectMultiplier      types.Int64  `tfsdk:"bfd_fast_detect_multiplier"`
 }
 type RouterStaticVRFIPv6UnicastNexthopAddresses struct {
 	Address        types.String `tfsdk:"address"`
@@ -189,6 +191,12 @@ func (data RouterStaticVRFIPv6Unicast) toBody(ctx context.Context) string {
 			}
 			if !item.Metric.IsNull() && !item.Metric.IsUnknown() {
 				body, _ = sjson.Set(body, "nexthop-interface-addresses.nexthop-interface-address"+"."+strconv.Itoa(index)+"."+"metric", strconv.FormatInt(item.Metric.ValueInt64(), 10))
+			}
+			if !item.BfdFastDetectMinimumInterval.IsNull() && !item.BfdFastDetectMinimumInterval.IsUnknown() {
+				body, _ = sjson.Set(body, "nexthop-interface-addresses.nexthop-interface-address"+"."+strconv.Itoa(index)+"."+"bfd.fast-detect.minimum-interval", strconv.FormatInt(item.BfdFastDetectMinimumInterval.ValueInt64(), 10))
+			}
+			if !item.BfdFastDetectMultiplier.IsNull() && !item.BfdFastDetectMultiplier.IsUnknown() {
+				body, _ = sjson.Set(body, "nexthop-interface-addresses.nexthop-interface-address"+"."+strconv.Itoa(index)+"."+"bfd.fast-detect.multiplier", strconv.FormatInt(item.BfdFastDetectMultiplier.ValueInt64(), 10))
 			}
 		}
 	}
@@ -448,6 +456,16 @@ func (data *RouterStaticVRFIPv6Unicast) updateFromBody(ctx context.Context, res 
 			data.NexthopInterfaceAddresses[i].Metric = types.Int64Value(value.Int())
 		} else {
 			data.NexthopInterfaceAddresses[i].Metric = types.Int64Null()
+		}
+		if value := r.Get("bfd.fast-detect.minimum-interval"); value.Exists() && !data.NexthopInterfaceAddresses[i].BfdFastDetectMinimumInterval.IsNull() {
+			data.NexthopInterfaceAddresses[i].BfdFastDetectMinimumInterval = types.Int64Value(value.Int())
+		} else {
+			data.NexthopInterfaceAddresses[i].BfdFastDetectMinimumInterval = types.Int64Null()
+		}
+		if value := r.Get("bfd.fast-detect.multiplier"); value.Exists() && !data.NexthopInterfaceAddresses[i].BfdFastDetectMultiplier.IsNull() {
+			data.NexthopInterfaceAddresses[i].BfdFastDetectMultiplier = types.Int64Value(value.Int())
+		} else {
+			data.NexthopInterfaceAddresses[i].BfdFastDetectMultiplier = types.Int64Null()
 		}
 	}
 	for i := range data.NexthopAddresses {
@@ -800,6 +818,12 @@ func (data *RouterStaticVRFIPv6Unicast) fromBody(ctx context.Context, res []byte
 			if cValue := v.Get("metric"); cValue.Exists() {
 				item.Metric = types.Int64Value(cValue.Int())
 			}
+			if cValue := v.Get("bfd.fast-detect.minimum-interval"); cValue.Exists() {
+				item.BfdFastDetectMinimumInterval = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("bfd.fast-detect.multiplier"); cValue.Exists() {
+				item.BfdFastDetectMultiplier = types.Int64Value(cValue.Int())
+			}
 			data.NexthopInterfaceAddresses = append(data.NexthopInterfaceAddresses, item)
 			return true
 		})
@@ -1005,6 +1029,12 @@ func (data *RouterStaticVRFIPv6UnicastData) fromBody(ctx context.Context, res []
 			}
 			if cValue := v.Get("metric"); cValue.Exists() {
 				item.Metric = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("bfd.fast-detect.minimum-interval"); cValue.Exists() {
+				item.BfdFastDetectMinimumInterval = types.Int64Value(cValue.Int())
+			}
+			if cValue := v.Get("bfd.fast-detect.multiplier"); cValue.Exists() {
+				item.BfdFastDetectMultiplier = types.Int64Value(cValue.Int())
 			}
 			data.NexthopInterfaceAddresses = append(data.NexthopInterfaceAddresses, item)
 			return true
@@ -1246,6 +1276,12 @@ func (data *RouterStaticVRFIPv6Unicast) getDeletedItems(ctx context.Context, sta
 				}
 				if !state.NexthopInterfaceAddresses[i].Metric.IsNull() && data.NexthopInterfaceAddresses[j].Metric.IsNull() {
 					deletedItems = append(deletedItems, fmt.Sprintf("%v/nexthop-interface-addresses/nexthop-interface-address%v/metric", state.getPath(), keyString))
+				}
+				if !state.NexthopInterfaceAddresses[i].BfdFastDetectMinimumInterval.IsNull() && data.NexthopInterfaceAddresses[j].BfdFastDetectMinimumInterval.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/nexthop-interface-addresses/nexthop-interface-address%v/bfd/fast-detect/minimum-interval", state.getPath(), keyString))
+				}
+				if !state.NexthopInterfaceAddresses[i].BfdFastDetectMultiplier.IsNull() && data.NexthopInterfaceAddresses[j].BfdFastDetectMultiplier.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/nexthop-interface-addresses/nexthop-interface-address%v/bfd/fast-detect/multiplier", state.getPath(), keyString))
 				}
 				break
 			}

--- a/internal/provider/resource_iosxr_router_static_vrf_ipv4_multicast.go
+++ b/internal/provider/resource_iosxr_router_static_vrf_ipv4_multicast.go
@@ -224,6 +224,20 @@ func (r *RouterStaticVRFIPv4MulticastResource) Schema(ctx context.Context, req r
 								int64validator.Between(1, 16777214),
 							},
 						},
+						"bfd_fast_detect_minimum_interval": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Hello interval").AddIntegerRangeDescription(3, 30000).String,
+							Optional:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(3, 30000),
+							},
+						},
+						"bfd_fast_detect_multiplier": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Detect multiplier").AddIntegerRangeDescription(1, 10).String,
+							Optional:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(1, 10),
+							},
+						},
 					},
 				},
 			},

--- a/internal/provider/resource_iosxr_router_static_vrf_ipv4_multicast_test.go
+++ b/internal/provider/resource_iosxr_router_static_vrf_ipv4_multicast_test.go
@@ -43,6 +43,8 @@ func TestAccIosxrRouterStaticVRFIPv4Multicast(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv4_multicast.test", "nexthop_interface_addresses.0.distance_metric", "144"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv4_multicast.test", "nexthop_interface_addresses.0.permanent", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv4_multicast.test", "nexthop_interface_addresses.0.metric", "10"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv4_multicast.test", "nexthop_interface_addresses.0.bfd_fast_detect_minimum_interval", "100"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv4_multicast.test", "nexthop_interface_addresses.0.bfd_fast_detect_multiplier", "3"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv4_multicast.test", "nexthop_addresses.0.address", "100.0.2.0"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv4_multicast.test", "nexthop_addresses.0.description", "ip-description"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv4_multicast.test", "nexthop_addresses.0.tag", "104"))
@@ -122,6 +124,8 @@ func testAccIosxrRouterStaticVRFIPv4MulticastConfig_all() string {
 	config += `		distance_metric = 144` + "\n"
 	config += `		permanent = true` + "\n"
 	config += `		metric = 10` + "\n"
+	config += `		bfd_fast_detect_minimum_interval = 100` + "\n"
+	config += `		bfd_fast_detect_multiplier = 3` + "\n"
 	config += `		}]` + "\n"
 	config += `	nexthop_addresses = [{` + "\n"
 	config += `		address = "100.0.2.0"` + "\n"

--- a/internal/provider/resource_iosxr_router_static_vrf_ipv4_unicast.go
+++ b/internal/provider/resource_iosxr_router_static_vrf_ipv4_unicast.go
@@ -224,6 +224,20 @@ func (r *RouterStaticVRFIPv4UnicastResource) Schema(ctx context.Context, req res
 								int64validator.Between(1, 16777214),
 							},
 						},
+						"bfd_fast_detect_minimum_interval": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Hello interval").AddIntegerRangeDescription(3, 30000).String,
+							Optional:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(3, 30000),
+							},
+						},
+						"bfd_fast_detect_multiplier": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Detect multiplier").AddIntegerRangeDescription(1, 10).String,
+							Optional:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(1, 10),
+							},
+						},
 					},
 				},
 			},

--- a/internal/provider/resource_iosxr_router_static_vrf_ipv4_unicast_test.go
+++ b/internal/provider/resource_iosxr_router_static_vrf_ipv4_unicast_test.go
@@ -43,6 +43,8 @@ func TestAccIosxrRouterStaticVRFIPv4Unicast(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv4_unicast.test", "nexthop_interface_addresses.0.distance_metric", "144"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv4_unicast.test", "nexthop_interface_addresses.0.permanent", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv4_unicast.test", "nexthop_interface_addresses.0.metric", "10"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv4_unicast.test", "nexthop_interface_addresses.0.bfd_fast_detect_minimum_interval", "100"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv4_unicast.test", "nexthop_interface_addresses.0.bfd_fast_detect_multiplier", "3"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv4_unicast.test", "nexthop_addresses.0.address", "100.0.2.0"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv4_unicast.test", "nexthop_addresses.0.description", "ip-description"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv4_unicast.test", "nexthop_addresses.0.tag", "104"))
@@ -122,6 +124,8 @@ func testAccIosxrRouterStaticVRFIPv4UnicastConfig_all() string {
 	config += `		distance_metric = 144` + "\n"
 	config += `		permanent = true` + "\n"
 	config += `		metric = 10` + "\n"
+	config += `		bfd_fast_detect_minimum_interval = 100` + "\n"
+	config += `		bfd_fast_detect_multiplier = 3` + "\n"
 	config += `		}]` + "\n"
 	config += `	nexthop_addresses = [{` + "\n"
 	config += `		address = "100.0.2.0"` + "\n"

--- a/internal/provider/resource_iosxr_router_static_vrf_ipv6_multicast.go
+++ b/internal/provider/resource_iosxr_router_static_vrf_ipv6_multicast.go
@@ -415,6 +415,20 @@ func (r *RouterStaticVRFIPv6MulticastResource) Schema(ctx context.Context, req r
 											int64validator.Between(1, 16777214),
 										},
 									},
+									"bfd_fast_detect_minimum_interval": schema.Int64Attribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Hello interval").AddIntegerRangeDescription(3, 30000).String,
+										Optional:            true,
+										Validators: []validator.Int64{
+											int64validator.Between(3, 30000),
+										},
+									},
+									"bfd_fast_detect_multiplier": schema.Int64Attribute{
+										MarkdownDescription: helpers.NewAttributeDescription("Detect multiplier").AddIntegerRangeDescription(1, 10).String,
+										Optional:            true,
+										Validators: []validator.Int64{
+											int64validator.Between(1, 10),
+										},
+									},
 								},
 							},
 						},

--- a/internal/provider/resource_iosxr_router_static_vrf_ipv6_multicast_test.go
+++ b/internal/provider/resource_iosxr_router_static_vrf_ipv6_multicast_test.go
@@ -63,6 +63,8 @@ func TestAccIosxrRouterStaticVRFIPv6Multicast(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv6_multicast.test", "vrfs.0.nexthop_interface_addresses.0.distance_metric", "144"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv6_multicast.test", "vrfs.0.nexthop_interface_addresses.0.permanent", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv6_multicast.test", "vrfs.0.nexthop_interface_addresses.0.metric", "10"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv6_multicast.test", "vrfs.0.nexthop_interface_addresses.0.bfd_fast_detect_minimum_interval", "100"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv6_multicast.test", "vrfs.0.nexthop_interface_addresses.0.bfd_fast_detect_multiplier", "3"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv6_multicast.test", "vrfs.0.nexthop_addresses.0.address", "3::3"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv6_multicast.test", "vrfs.0.nexthop_addresses.0.description", "ip-description"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv6_multicast.test", "vrfs.0.nexthop_addresses.0.tag", "104"))
@@ -149,6 +151,8 @@ func testAccIosxrRouterStaticVRFIPv6MulticastConfig_all() string {
 	config += `			distance_metric = 144` + "\n"
 	config += `			permanent = true` + "\n"
 	config += `			metric = 10` + "\n"
+	config += `			bfd_fast_detect_minimum_interval = 100` + "\n"
+	config += `			bfd_fast_detect_multiplier = 3` + "\n"
 	config += `		}]` + "\n"
 	config += `		nexthop_addresses = [{` + "\n"
 	config += `			address = "3::3"` + "\n"

--- a/internal/provider/resource_iosxr_router_static_vrf_ipv6_unicast.go
+++ b/internal/provider/resource_iosxr_router_static_vrf_ipv6_unicast.go
@@ -226,6 +226,20 @@ func (r *RouterStaticVRFIPv6UnicastResource) Schema(ctx context.Context, req res
 								int64validator.Between(1, 16777214),
 							},
 						},
+						"bfd_fast_detect_minimum_interval": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Hello interval").AddIntegerRangeDescription(3, 30000).String,
+							Optional:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(3, 30000),
+							},
+						},
+						"bfd_fast_detect_multiplier": schema.Int64Attribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Detect multiplier").AddIntegerRangeDescription(1, 10).String,
+							Optional:            true,
+							Validators: []validator.Int64{
+								int64validator.Between(1, 10),
+							},
+						},
 					},
 				},
 			},

--- a/internal/provider/resource_iosxr_router_static_vrf_ipv6_unicast_test.go
+++ b/internal/provider/resource_iosxr_router_static_vrf_ipv6_unicast_test.go
@@ -43,6 +43,8 @@ func TestAccIosxrRouterStaticVRFIPv6Unicast(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv6_unicast.test", "nexthop_interface_addresses.0.distance_metric", "144"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv6_unicast.test", "nexthop_interface_addresses.0.permanent", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv6_unicast.test", "nexthop_interface_addresses.0.metric", "10"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv6_unicast.test", "nexthop_interface_addresses.0.bfd_fast_detect_minimum_interval", "100"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv6_unicast.test", "nexthop_interface_addresses.0.bfd_fast_detect_multiplier", "3"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv6_unicast.test", "nexthop_addresses.0.address", "3::3"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv6_unicast.test", "nexthop_addresses.0.description", "ip-description"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_router_static_vrf_ipv6_unicast.test", "nexthop_addresses.0.tag", "104"))
@@ -122,6 +124,8 @@ func testAccIosxrRouterStaticVRFIPv6UnicastConfig_all() string {
 	config += `		distance_metric = 144` + "\n"
 	config += `		permanent = true` + "\n"
 	config += `		metric = 10` + "\n"
+	config += `		bfd_fast_detect_minimum_interval = 100` + "\n"
+	config += `		bfd_fast_detect_multiplier = 3` + "\n"
 	config += `		}]` + "\n"
 	config += `	nexthop_addresses = [{` + "\n"
 	config += `		address = "3::3"` + "\n"


### PR DESCRIPTION
Add:
- bfd_fast_detect_minimum_interval
- bfd_fast_detect_multiplier

to the 4 definition files:
- gen/definitions/router_static_vrf_ipv4_unicast.yaml
- gen/definitions/router_static_vrf_ipv4_multicast.yaml
- gen/definitions/router_static_vrf_ipv6_unicast.yaml
- gen/definitions/router_static_vrf_ipv6_multicast.yaml
