### PR TITLE
Add SNMP context and VRF context support

### DIFF
--- a/docs/data-sources/snmp_server.md
+++ b/docs/data-sources/snmp_server.md
@@ -28,6 +28,7 @@ data "iosxr_snmp_server" "example" {
 
 - `communities` (Attributes List) The UNENCRYPTED (cleartext) community string (see [below for nested schema](#nestedatt--communities))
 - `contact` (String) Text for mib Object sysContact
+- `contexts` (Attributes List) Context Name (see [below for nested schema](#nestedatt--contexts))
 - `groups` (Attributes List) Name of the group (see [below for nested schema](#nestedatt--groups))
 - `id` (String) The path of the retrieved object.
 - `location` (String) Text for mib Object sysLocation
@@ -73,6 +74,7 @@ data "iosxr_snmp_server" "example" {
 - `traps_snmp_linkup` (Boolean) Enable SNMPv2-MIB linkUp traps
 - `traps_system` (Boolean) Enable SNMP SYSTEMMIB-MIB traps
 - `users` (Attributes List) Name of the user (see [below for nested schema](#nestedatt--users))
+- `vrfs` (Attributes List) VRF name (see [below for nested schema](#nestedatt--vrfs))
 
 <a id="nestedatt--communities"></a>
 ### Nested Schema for `communities`
@@ -87,6 +89,14 @@ Read-Only:
 - `sdrowner` (Boolean) SDR Owner permissions for MIB Objects
 - `systemowner` (Boolean) System Owner permissions for MIB objects
 - `view` (String) Restrict this community to a named view
+
+
+<a id="nestedatt--contexts"></a>
+### Nested Schema for `contexts`
+
+Read-Only:
+
+- `context_name` (String) Context Name
 
 
 <a id="nestedatt--groups"></a>
@@ -119,3 +129,12 @@ Read-Only:
 - `v3_priv_aes_aes_128_encryption_aes` (String) Specifies an aes-128 ENCRYPTED authentication password
 - `v3_priv_aes_aes_128_encryption_default` (String) Specifies an default ENCRYPTED authentication password
 - `v3_systemowner` (Boolean) System Owner permissions for MIB objects
+
+
+<a id="nestedatt--vrfs"></a>
+### Nested Schema for `vrfs`
+
+Read-Only:
+
+- `context` (String) SNMP Context Name
+- `vrf_name` (String) VRF name

--- a/docs/resources/snmp_server.md
+++ b/docs/resources/snmp_server.md
@@ -39,6 +39,17 @@ resource "iosxr_snmp_server" "example" {
   traps_isis_authentication_failure = "enable"
   traps_bgp_cbgp2_updown            = true
   traps_bgp_bgp4_mib_updown         = true
+  contexts = [
+    {
+      context_name = "CONT-NAME1"
+    }
+  ]
+  vrfs = [
+    {
+      vrf_name = "VRF1"
+      context  = "CONT-VRF-VRF1"
+    }
+  ]
   users = [
     {
       user_name                  = "USER1"
@@ -82,6 +93,7 @@ resource "iosxr_snmp_server" "example" {
 
 - `communities` (Attributes List) The UNENCRYPTED (cleartext) community string (see [below for nested schema](#nestedatt--communities))
 - `contact` (String) Text for mib Object sysContact
+- `contexts` (Attributes List) Context Name (see [below for nested schema](#nestedatt--contexts))
 - `delete_mode` (String) Configure behavior when deleting/destroying the resource. Either delete the entire object (YANG container) being managed, or only delete the individual resource attributes configured explicitly and leave everything else as-is. Default value is `all`.
   - Choices: `all`, `attributes`
 - `device` (String) A device name from the provider configuration.
@@ -167,6 +179,7 @@ resource "iosxr_snmp_server" "example" {
 - `traps_snmp_linkup` (Boolean) Enable SNMPv2-MIB linkUp traps
 - `traps_system` (Boolean) Enable SNMP SYSTEMMIB-MIB traps
 - `users` (Attributes List) Name of the user (see [below for nested schema](#nestedatt--users))
+- `vrfs` (Attributes List) VRF name (see [below for nested schema](#nestedatt--vrfs))
 
 ### Read-Only
 
@@ -188,6 +201,14 @@ Optional:
 - `sdrowner` (Boolean) SDR Owner permissions for MIB Objects
 - `systemowner` (Boolean) System Owner permissions for MIB objects
 - `view` (String) Restrict this community to a named view
+
+
+<a id="nestedatt--contexts"></a>
+### Nested Schema for `contexts`
+
+Required:
+
+- `context_name` (String) Context Name
 
 
 <a id="nestedatt--groups"></a>
@@ -226,6 +247,18 @@ Optional:
 - `v3_priv_aes_aes_128_encryption_aes` (String) Specifies an aes-128 ENCRYPTED authentication password
 - `v3_priv_aes_aes_128_encryption_default` (String) Specifies an default ENCRYPTED authentication password
 - `v3_systemowner` (Boolean) System Owner permissions for MIB objects
+
+
+<a id="nestedatt--vrfs"></a>
+### Nested Schema for `vrfs`
+
+Required:
+
+- `vrf_name` (String) VRF name
+
+Optional:
+
+- `context` (String) SNMP Context Name
 
 ## Import
 

--- a/examples/resources/iosxr_snmp_server/resource.tf
+++ b/examples/resources/iosxr_snmp_server/resource.tf
@@ -24,6 +24,17 @@ resource "iosxr_snmp_server" "example" {
   traps_isis_authentication_failure = "enable"
   traps_bgp_cbgp2_updown            = true
   traps_bgp_bgp4_mib_updown         = true
+  contexts = [
+    {
+      context_name = "CONT-NAME1"
+    }
+  ]
+  vrfs = [
+    {
+      vrf_name = "VRF1"
+      context  = "CONT-VRF-VRF1"
+    }
+  ]
   users = [
     {
       user_name                  = "USER1"

--- a/gen/definitions/snmp_server.yaml
+++ b/gen/definitions/snmp_server.yaml
@@ -126,6 +126,24 @@ attributes:
     example: true
   - yang_name: traps/Cisco-IOS-XR-um-router-bgp-cfg:bgp/bgp4-mib-updown
     example: true
+  - yang_name: context/contexts/context
+    tf_name: contexts
+    type: List
+    attributes:
+      - yang_name: context-name
+        id: true
+        example: CONT-NAME1
+  - yang_name: vrfs/vrf
+    tf_name: vrfs
+    type: List
+    attributes:
+      - yang_name: vrf-name
+        example: VRF1
+        id: true
+      - yang_name: contexts/context/context-name
+        tf_name: context
+        example: CONT-VRF-VRF1
+        delete_parent: true
   - yang_name: users/user
     tf_name: users
     type: List

--- a/internal/provider/data_source_iosxr_snmp_server.go
+++ b/internal/provider/data_source_iosxr_snmp_server.go
@@ -234,6 +234,34 @@ func (d *SNMPServerDataSource) Schema(ctx context.Context, req datasource.Schema
 				MarkdownDescription: "Enable CISCO-BGP4-MIB v2 up/down traps",
 				Computed:            true,
 			},
+			"contexts": schema.ListNestedAttribute{
+				MarkdownDescription: "Context Name",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"context_name": schema.StringAttribute{
+							MarkdownDescription: "Context Name",
+							Computed:            true,
+						},
+					},
+				},
+			},
+			"vrfs": schema.ListNestedAttribute{
+				MarkdownDescription: "VRF name",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"vrf_name": schema.StringAttribute{
+							MarkdownDescription: "VRF name",
+							Computed:            true,
+						},
+						"context": schema.StringAttribute{
+							MarkdownDescription: "SNMP Context Name",
+							Computed:            true,
+						},
+					},
+				},
+			},
 			"users": schema.ListNestedAttribute{
 				MarkdownDescription: "Name of the user",
 				Computed:            true,

--- a/internal/provider/data_source_iosxr_snmp_server_test.go
+++ b/internal/provider/data_source_iosxr_snmp_server_test.go
@@ -52,6 +52,9 @@ func TestAccDataSourceIosxrSNMPServer(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_snmp_server.test", "traps_isis_authentication_failure", "enable"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_snmp_server.test", "traps_bgp_cbgp2_updown", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_snmp_server.test", "traps_bgp_bgp4_mib_updown", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_snmp_server.test", "contexts.0.context_name", "CONT-NAME1"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_snmp_server.test", "vrfs.0.vrf_name", "VRF1"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_snmp_server.test", "vrfs.0.context", "CONT-VRF-VRF1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_snmp_server.test", "users.0.user_name", "USER1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_snmp_server.test", "users.0.group_name", "GROUP1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_snmp_server.test", "users.0.v3_auth_md5_encryption_aes", "073C05626E2A4841141D"))
@@ -113,6 +116,13 @@ func testAccDataSourceIosxrSNMPServerConfig() string {
 	config += `	traps_isis_authentication_failure = "enable"` + "\n"
 	config += `	traps_bgp_cbgp2_updown = true` + "\n"
 	config += `	traps_bgp_bgp4_mib_updown = true` + "\n"
+	config += `	contexts = [{` + "\n"
+	config += `		context_name = "CONT-NAME1"` + "\n"
+	config += `	}]` + "\n"
+	config += `	vrfs = [{` + "\n"
+	config += `		vrf_name = "VRF1"` + "\n"
+	config += `		context = "CONT-VRF-VRF1"` + "\n"
+	config += `	}]` + "\n"
 	config += `	users = [{` + "\n"
 	config += `		user_name = "USER1"` + "\n"
 	config += `		group_name = "GROUP1"` + "\n"

--- a/internal/provider/model_iosxr_snmp_server.go
+++ b/internal/provider/model_iosxr_snmp_server.go
@@ -77,6 +77,8 @@ type SNMPServer struct {
 	TrapsIsisLspErrorDetected           types.String            `tfsdk:"traps_isis_lsp_error_detected"`
 	TrapsBgpCbgp2Updown                 types.Bool              `tfsdk:"traps_bgp_cbgp2_updown"`
 	TrapsBgpBgp4MibUpdown               types.Bool              `tfsdk:"traps_bgp_bgp4_mib_updown"`
+	Contexts                            []SNMPServerContexts    `tfsdk:"contexts"`
+	Vrfs                                []SNMPServerVrfs        `tfsdk:"vrfs"`
 	Users                               []SNMPServerUsers       `tfsdk:"users"`
 	Groups                              []SNMPServerGroups      `tfsdk:"groups"`
 	Communities                         []SNMPServerCommunities `tfsdk:"communities"`
@@ -128,9 +130,18 @@ type SNMPServerData struct {
 	TrapsIsisLspErrorDetected           types.String            `tfsdk:"traps_isis_lsp_error_detected"`
 	TrapsBgpCbgp2Updown                 types.Bool              `tfsdk:"traps_bgp_cbgp2_updown"`
 	TrapsBgpBgp4MibUpdown               types.Bool              `tfsdk:"traps_bgp_bgp4_mib_updown"`
+	Contexts                            []SNMPServerContexts    `tfsdk:"contexts"`
+	Vrfs                                []SNMPServerVrfs        `tfsdk:"vrfs"`
 	Users                               []SNMPServerUsers       `tfsdk:"users"`
 	Groups                              []SNMPServerGroups      `tfsdk:"groups"`
 	Communities                         []SNMPServerCommunities `tfsdk:"communities"`
+}
+type SNMPServerContexts struct {
+	ContextName types.String `tfsdk:"context_name"`
+}
+type SNMPServerVrfs struct {
+	VrfName types.String `tfsdk:"vrf_name"`
+	Context types.String `tfsdk:"context"`
 }
 type SNMPServerUsers struct {
 	UserName                         types.String `tfsdk:"user_name"`
@@ -344,6 +355,25 @@ func (data SNMPServer) toBody(ctx context.Context) string {
 	if !data.TrapsBgpBgp4MibUpdown.IsNull() && !data.TrapsBgpBgp4MibUpdown.IsUnknown() {
 		if data.TrapsBgpBgp4MibUpdown.ValueBool() {
 			body, _ = sjson.Set(body, "traps.Cisco-IOS-XR-um-router-bgp-cfg:bgp.bgp4-mib-updown", map[string]string{})
+		}
+	}
+	if len(data.Contexts) > 0 {
+		body, _ = sjson.Set(body, "context.contexts.context", []interface{}{})
+		for index, item := range data.Contexts {
+			if !item.ContextName.IsNull() && !item.ContextName.IsUnknown() {
+				body, _ = sjson.Set(body, "context.contexts.context"+"."+strconv.Itoa(index)+"."+"context-name", item.ContextName.ValueString())
+			}
+		}
+	}
+	if len(data.Vrfs) > 0 {
+		body, _ = sjson.Set(body, "vrfs.vrf", []interface{}{})
+		for index, item := range data.Vrfs {
+			if !item.VrfName.IsNull() && !item.VrfName.IsUnknown() {
+				body, _ = sjson.Set(body, "vrfs.vrf"+"."+strconv.Itoa(index)+"."+"vrf-name", item.VrfName.ValueString())
+			}
+			if !item.Context.IsNull() && !item.Context.IsUnknown() {
+				body, _ = sjson.Set(body, "vrfs.vrf"+"."+strconv.Itoa(index)+"."+"contexts.context.context-name", item.Context.ValueString())
+			}
 		}
 	}
 	if len(data.Users) > 0 {
@@ -754,6 +784,69 @@ func (data *SNMPServer) updateFromBody(ctx context.Context, res []byte) {
 	} else {
 		data.TrapsBgpBgp4MibUpdown = types.BoolNull()
 	}
+	for i := range data.Contexts {
+		keys := [...]string{"context-name"}
+		keyValues := [...]string{data.Contexts[i].ContextName.ValueString()}
+
+		var r gjson.Result
+		gjson.GetBytes(res, "context.contexts.context").ForEach(
+			func(_, v gjson.Result) bool {
+				found := false
+				for ik := range keys {
+					if v.Get(keys[ik]).String() == keyValues[ik] {
+						found = true
+						continue
+					}
+					found = false
+					break
+				}
+				if found {
+					r = v
+					return false
+				}
+				return true
+			},
+		)
+		if value := r.Get("context-name"); value.Exists() && !data.Contexts[i].ContextName.IsNull() {
+			data.Contexts[i].ContextName = types.StringValue(value.String())
+		} else {
+			data.Contexts[i].ContextName = types.StringNull()
+		}
+	}
+	for i := range data.Vrfs {
+		keys := [...]string{"vrf-name"}
+		keyValues := [...]string{data.Vrfs[i].VrfName.ValueString()}
+
+		var r gjson.Result
+		gjson.GetBytes(res, "vrfs.vrf").ForEach(
+			func(_, v gjson.Result) bool {
+				found := false
+				for ik := range keys {
+					if v.Get(keys[ik]).String() == keyValues[ik] {
+						found = true
+						continue
+					}
+					found = false
+					break
+				}
+				if found {
+					r = v
+					return false
+				}
+				return true
+			},
+		)
+		if value := r.Get("vrf-name"); value.Exists() && !data.Vrfs[i].VrfName.IsNull() {
+			data.Vrfs[i].VrfName = types.StringValue(value.String())
+		} else {
+			data.Vrfs[i].VrfName = types.StringNull()
+		}
+		if value := r.Get("contexts.context.context-name"); value.Exists() && !data.Vrfs[i].Context.IsNull() {
+			data.Vrfs[i].Context = types.StringValue(value.String())
+		} else {
+			data.Vrfs[i].Context = types.StringNull()
+		}
+	}
 	for i := range data.Users {
 		keys := [...]string{"user-name"}
 		keyValues := [...]string{data.Users[i].UserName.ValueString()}
@@ -1154,6 +1247,31 @@ func (data *SNMPServer) fromBody(ctx context.Context, res []byte) {
 	} else {
 		data.TrapsBgpBgp4MibUpdown = types.BoolValue(false)
 	}
+	if value := gjson.GetBytes(res, "context.contexts.context"); value.Exists() {
+		data.Contexts = make([]SNMPServerContexts, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := SNMPServerContexts{}
+			if cValue := v.Get("context-name"); cValue.Exists() {
+				item.ContextName = types.StringValue(cValue.String())
+			}
+			data.Contexts = append(data.Contexts, item)
+			return true
+		})
+	}
+	if value := gjson.GetBytes(res, "vrfs.vrf"); value.Exists() {
+		data.Vrfs = make([]SNMPServerVrfs, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := SNMPServerVrfs{}
+			if cValue := v.Get("vrf-name"); cValue.Exists() {
+				item.VrfName = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("contexts.context.context-name"); cValue.Exists() {
+				item.Context = types.StringValue(cValue.String())
+			}
+			data.Vrfs = append(data.Vrfs, item)
+			return true
+		})
+	}
 	if value := gjson.GetBytes(res, "users.user"); value.Exists() {
 		data.Users = make([]SNMPServerUsers, 0)
 		value.ForEach(func(k, v gjson.Result) bool {
@@ -1442,6 +1560,31 @@ func (data *SNMPServerData) fromBody(ctx context.Context, res []byte) {
 	} else {
 		data.TrapsBgpBgp4MibUpdown = types.BoolValue(false)
 	}
+	if value := gjson.GetBytes(res, "context.contexts.context"); value.Exists() {
+		data.Contexts = make([]SNMPServerContexts, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := SNMPServerContexts{}
+			if cValue := v.Get("context-name"); cValue.Exists() {
+				item.ContextName = types.StringValue(cValue.String())
+			}
+			data.Contexts = append(data.Contexts, item)
+			return true
+		})
+	}
+	if value := gjson.GetBytes(res, "vrfs.vrf"); value.Exists() {
+		data.Vrfs = make([]SNMPServerVrfs, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := SNMPServerVrfs{}
+			if cValue := v.Get("vrf-name"); cValue.Exists() {
+				item.VrfName = types.StringValue(cValue.String())
+			}
+			if cValue := v.Get("contexts.context.context-name"); cValue.Exists() {
+				item.Context = types.StringValue(cValue.String())
+			}
+			data.Vrfs = append(data.Vrfs, item)
+			return true
+		})
+	}
 	if value := gjson.GetBytes(res, "users.user"); value.Exists() {
 		data.Users = make([]SNMPServerUsers, 0)
 		value.ForEach(func(k, v gjson.Result) bool {
@@ -1689,6 +1832,69 @@ func (data *SNMPServer) getDeletedItems(ctx context.Context, state SNMPServer) [
 	if !state.TrapsBgpBgp4MibUpdown.IsNull() && data.TrapsBgpBgp4MibUpdown.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/traps/Cisco-IOS-XR-um-router-bgp-cfg:bgp/bgp4-mib-updown", state.getPath()))
 	}
+	for i := range state.Contexts {
+		keys := [...]string{"context-name"}
+		stateKeyValues := [...]string{state.Contexts[i].ContextName.ValueString()}
+		keyString := ""
+		for ki := range keys {
+			keyString += "[" + keys[ki] + "=" + stateKeyValues[ki] + "]"
+		}
+
+		emptyKeys := true
+		if !reflect.ValueOf(state.Contexts[i].ContextName.ValueString()).IsZero() {
+			emptyKeys = false
+		}
+		if emptyKeys {
+			continue
+		}
+
+		found := false
+		for j := range data.Contexts {
+			found = true
+			if state.Contexts[i].ContextName.ValueString() != data.Contexts[j].ContextName.ValueString() {
+				found = false
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			deletedItems = append(deletedItems, fmt.Sprintf("%v/context/contexts/context%v", state.getPath(), keyString))
+		}
+	}
+	for i := range state.Vrfs {
+		keys := [...]string{"vrf-name"}
+		stateKeyValues := [...]string{state.Vrfs[i].VrfName.ValueString()}
+		keyString := ""
+		for ki := range keys {
+			keyString += "[" + keys[ki] + "=" + stateKeyValues[ki] + "]"
+		}
+
+		emptyKeys := true
+		if !reflect.ValueOf(state.Vrfs[i].VrfName.ValueString()).IsZero() {
+			emptyKeys = false
+		}
+		if emptyKeys {
+			continue
+		}
+
+		found := false
+		for j := range data.Vrfs {
+			found = true
+			if state.Vrfs[i].VrfName.ValueString() != data.Vrfs[j].VrfName.ValueString() {
+				found = false
+			}
+			if found {
+				if !state.Vrfs[i].Context.IsNull() && data.Vrfs[j].Context.IsNull() {
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/vrfs/vrf%v/contexts/context", state.getPath(), keyString))
+				}
+				break
+			}
+		}
+		if !found {
+			deletedItems = append(deletedItems, fmt.Sprintf("%v/vrfs/vrf%v", state.getPath(), keyString))
+		}
+	}
 	for i := range state.Users {
 		keys := [...]string{"user-name"}
 		stateKeyValues := [...]string{state.Users[i].UserName.ValueString()}
@@ -1916,6 +2122,22 @@ func (data *SNMPServer) getEmptyLeafsDelete(ctx context.Context) []string {
 	if !data.TrapsBgpBgp4MibUpdown.IsNull() && !data.TrapsBgpBgp4MibUpdown.ValueBool() {
 		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/traps/Cisco-IOS-XR-um-router-bgp-cfg:bgp/bgp4-mib-updown", data.getPath()))
 	}
+	for i := range data.Contexts {
+		keys := [...]string{"context-name"}
+		keyValues := [...]string{data.Contexts[i].ContextName.ValueString()}
+		keyString := ""
+		for ki := range keys {
+			keyString += "[" + keys[ki] + "=" + keyValues[ki] + "]"
+		}
+	}
+	for i := range data.Vrfs {
+		keys := [...]string{"vrf-name"}
+		keyValues := [...]string{data.Vrfs[i].VrfName.ValueString()}
+		keyString := ""
+		for ki := range keys {
+			keyString += "[" + keys[ki] + "=" + keyValues[ki] + "]"
+		}
+	}
 	for i := range data.Users {
 		keys := [...]string{"user-name"}
 		keyValues := [...]string{data.Users[i].UserName.ValueString()}
@@ -2091,6 +2313,26 @@ func (data *SNMPServer) getDeletePaths(ctx context.Context) []string {
 	}
 	if !data.TrapsBgpBgp4MibUpdown.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/traps/Cisco-IOS-XR-um-router-bgp-cfg:bgp/bgp4-mib-updown", data.getPath()))
+	}
+	for i := range data.Contexts {
+		keys := [...]string{"context-name"}
+		keyValues := [...]string{data.Contexts[i].ContextName.ValueString()}
+
+		keyString := ""
+		for ki := range keys {
+			keyString += "[" + keys[ki] + "=" + keyValues[ki] + "]"
+		}
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/context/contexts/context%v", data.getPath(), keyString))
+	}
+	for i := range data.Vrfs {
+		keys := [...]string{"vrf-name"}
+		keyValues := [...]string{data.Vrfs[i].VrfName.ValueString()}
+
+		keyString := ""
+		for ki := range keys {
+			keyString += "[" + keys[ki] + "=" + keyValues[ki] + "]"
+		}
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/vrfs/vrf%v", data.getPath(), keyString))
 	}
 	for i := range data.Users {
 		keys := [...]string{"user-name"}

--- a/internal/provider/resource_iosxr_snmp_server.go
+++ b/internal/provider/resource_iosxr_snmp_server.go
@@ -351,6 +351,46 @@ func (r *SNMPServerResource) Schema(ctx context.Context, req resource.SchemaRequ
 				MarkdownDescription: helpers.NewAttributeDescription("Enable CISCO-BGP4-MIB v2 up/down traps").String,
 				Optional:            true,
 			},
+			"contexts": schema.ListNestedAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Context Name").String,
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"context_name": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Context Name").String,
+							Required:            true,
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(1, 32),
+								stringvalidator.RegexMatches(regexp.MustCompile(`[\w\-\.:,_@#%$\+=\|;]+`), ""),
+							},
+						},
+					},
+				},
+			},
+			"vrfs": schema.ListNestedAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("VRF name").String,
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"vrf_name": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("VRF name").String,
+							Required:            true,
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(1, 32),
+								stringvalidator.RegexMatches(regexp.MustCompile(`[\w\-\.:,_@#%$\+=\|;]+`), ""),
+							},
+						},
+						"context": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("SNMP Context Name").String,
+							Optional:            true,
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(1, 32),
+								stringvalidator.RegexMatches(regexp.MustCompile(`[\w\-\.:,_@#%$\+=\|;]+`), ""),
+							},
+						},
+					},
+				},
+			},
 			"users": schema.ListNestedAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Name of the user").String,
 				Optional:            true,

--- a/internal/provider/resource_iosxr_snmp_server_test.go
+++ b/internal/provider/resource_iosxr_snmp_server_test.go
@@ -53,6 +53,9 @@ func TestAccIosxrSNMPServer(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_snmp_server.test", "traps_isis_authentication_failure", "enable"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_snmp_server.test", "traps_bgp_cbgp2_updown", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_snmp_server.test", "traps_bgp_bgp4_mib_updown", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_snmp_server.test", "contexts.0.context_name", "CONT-NAME1"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_snmp_server.test", "vrfs.0.vrf_name", "VRF1"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_snmp_server.test", "vrfs.0.context", "CONT-VRF-VRF1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_snmp_server.test", "users.0.user_name", "USER1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_snmp_server.test", "users.0.group_name", "GROUP1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_snmp_server.test", "users.0.v3_auth_md5_encryption_aes", "073C05626E2A4841141D"))
@@ -130,6 +133,13 @@ func testAccIosxrSNMPServerConfig_all() string {
 	config += `	traps_isis_authentication_failure = "enable"` + "\n"
 	config += `	traps_bgp_cbgp2_updown = true` + "\n"
 	config += `	traps_bgp_bgp4_mib_updown = true` + "\n"
+	config += `	contexts = [{` + "\n"
+	config += `		context_name = "CONT-NAME1"` + "\n"
+	config += `		}]` + "\n"
+	config += `	vrfs = [{` + "\n"
+	config += `		vrf_name = "VRF1"` + "\n"
+	config += `		context = "CONT-VRF-VRF1"` + "\n"
+	config += `		}]` + "\n"
 	config += `	users = [{` + "\n"
 	config += `		user_name = "USER1"` + "\n"
 	config += `		group_name = "GROUP1"` + "\n"


### PR DESCRIPTION
Add support for configuring SNMP contexts and VRF-context mappings in IOS-XR. This enhancement allows users to create SNMP contexts and associate them with specific VRFs, enabling more granular SNMP access control and management.

### Changes
- Add `contexts` configuration block to support SNMP context definitions
  - Add `context-name` attribute for context identification
- Add `vrfs` configuration block for VRF-specific SNMP settings
  - Add `vrf-name` for VRF identification
  - Add `context` attribute to associate VRFs with SNMP contexts
  
### Alternative solution
  
We could also create a new resource for the VRF's under SNMP-server.  This raises a design question about when to create new resources versus extending existing ones.

E.g. with the following code:

```
name: SNMP Server VRF
path: Cisco-IOS-XR-um-snmp-server-cfg:/snmp-server/vrfs/vrf[vrf-name=%s]
doc_category: Management
attributes:
  - yang_name: vrf-name
    example: VRF1
  - yang_name: contexts/context/context-name
    tf_name: context
    example: cont-vrf-VRF1
```
 
In this case, it would make sense to integrate `iosxr_snmp_server_vrf_host` to the new resource `iosxr_snmp_server_vrf`, but this would be a breaking change.

@danischm can you provide feedback on the preferred solution?