### PR TITLE
Prevent gNMI set operation error "bad-element": "keepalive-interval" …

### DIFF
--- a/gen/definitions/router_bgp_vrf.yaml
+++ b/gen/definitions/router_bgp_vrf.yaml
@@ -111,9 +111,11 @@ attributes:
         example: false
       - yang_name: timers/keepalive-interval
         optional: true
+        delete_parent: true
         example: 5
       - yang_name: timers/holdtime
         optional: true
+        delete_parent: true
         example: 20
       - yang_name: update-source
         example: GigabitEthernet0/0/0/1

--- a/internal/provider/model_iosxr_router_bgp_vrf.go
+++ b/internal/provider/model_iosxr_router_bgp_vrf.go
@@ -920,10 +920,10 @@ func (data *RouterBGPVRF) getDeletedItems(ctx context.Context, state RouterBGPVR
 					deletedItems = append(deletedItems, fmt.Sprintf("%v/neighbors/neighbor%v/shutdown", state.getPath(), keyString))
 				}
 				if !state.Neighbors[i].TimersKeepaliveInterval.IsNull() && data.Neighbors[j].TimersKeepaliveInterval.IsNull() {
-					deletedItems = append(deletedItems, fmt.Sprintf("%v/neighbors/neighbor%v/timers/keepalive-interval", state.getPath(), keyString))
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/neighbors/neighbor%v/timers", state.getPath(), keyString))
 				}
 				if !state.Neighbors[i].TimersHoldtime.IsNull() && data.Neighbors[j].TimersHoldtime.IsNull() {
-					deletedItems = append(deletedItems, fmt.Sprintf("%v/neighbors/neighbor%v/timers/holdtime", state.getPath(), keyString))
+					deletedItems = append(deletedItems, fmt.Sprintf("%v/neighbors/neighbor%v/timers", state.getPath(), keyString))
 				}
 				if !state.Neighbors[i].UpdateSource.IsNull() && data.Neighbors[j].UpdateSource.IsNull() {
 					deletedItems = append(deletedItems, fmt.Sprintf("%v/neighbors/neighbor%v/update-source", state.getPath(), keyString))


### PR DESCRIPTION
…when removing BGP timers from router_bgp_vrf_neighbor