### PR TITLE
Batch Manager

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,9 +38,12 @@ provider "iosxr" {
 
 ### Optional
 
+- `batch_max_size` (Number) Maximum size of a batch. This can also be set as the IOSXR_BATCH_MAX_SIZE environment variable. Defaults to `10`.
+- `batch_timeout` (Number) Timeout for batching in milliseconds. This can also be set as the IOSXR_BATCH_TIMEOUT environment variable. Defaults to `100`.
 - `ca_certificate` (String) TLS CA certificate content. This can also be set as the IOSXR_CA_CERTIFICATE environment variable.
 - `certificate` (String) TLS certificate content. This can also be set as the IOSXR_CERTIFICATE environment variable.
 - `devices` (Attributes List) This can be used to manage a list of devices from a single provider. All devices must use the same credentials. Each resource and data source has an optional attribute named `device`, which can then select a device by its name from this list. (see [below for nested schema](#nestedatt--devices))
+- `enable_batching` (Boolean) Enable batching of gNMI set requests. This can also be set as the IOSXR_ENABLE_BATCHING environment variable. Defaults to `true`.
 - `host` (String) IP or name of the Cisco IOS-XR device. Optionally a port can be added with `:12345`. The default port is `57400`. This can also be set as the IOSXR_HOST environment variable. If no `host` is provided, the `host` of the first device from the `devices` list is being used.
 - `key` (String) TLS private key content. This can also be set as the IOSXR_KEY environment variable.
 - `password` (String, Sensitive) Password for the IOS-XR device. This can also be set as the IOSXR_PASSWORD environment variable.

--- a/gen/templates/provider.go
+++ b/gen/templates/provider.go
@@ -23,6 +23,8 @@ package provider
 import (
 	"context"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -52,6 +54,9 @@ type providerData struct {
 	Key               types.String         `tfsdk:"key"`
 	CaCertificate     types.String         `tfsdk:"ca_certificate"`
 	ReuseConnection   types.Bool           `tfsdk:"reuse_connection"`
+	EnableBatching    types.Bool           `tfsdk:"enable_batching"`
+	BatchTimeout      types.Int64          `tfsdk:"batch_timeout"`
+	BatchMaxSize      types.Int64          `tfsdk:"batch_max_size"`
 	Devices           []providerDataDevice `tfsdk:"devices"`
 }
 
@@ -103,6 +108,18 @@ func (p *iosxrProvider) Schema(ctx context.Context, req provider.SchemaRequest, 
 			},
 			"reuse_connection": schema.BoolAttribute{
 				MarkdownDescription: "Reuse gNMI connection. This can also be set as the IOSXR_REUSE_CONNECTION environment variable. Defaults to `true`.",
+				Optional:            true,
+			},
+			"enable_batching": schema.BoolAttribute{
+				MarkdownDescription: "Enable batching of gNMI set requests. This can also be set as the IOSXR_ENABLE_BATCHING environment variable. Defaults to `true`.",
+				Optional:            true,
+			},
+			"batch_timeout": schema.Int64Attribute{
+				MarkdownDescription: "Timeout for batching in milliseconds. This can also be set as the IOSXR_BATCH_TIMEOUT environment variable. Defaults to `100`.",
+				Optional:            true,
+			},
+			"batch_max_size": schema.Int64Attribute{
+				MarkdownDescription: "Maximum size of a batch. This can also be set as the IOSXR_BATCH_MAX_SIZE environment variable. Defaults to `10`.",
 				Optional:            true,
 			},
 			"devices": schema.ListNestedAttribute{
@@ -326,7 +343,49 @@ func (p *iosxrProvider) Configure(ctx context.Context, req provider.ConfigureReq
 		reuseConnection = config.ReuseConnection.ValueBool()
 	}
 
+	// Configure batching options
+	var enableBatching bool
+	if config.EnableBatching.IsNull() {
+		enableBatchingStr := os.Getenv("IOSXR_ENABLE_BATCHING")
+		if enableBatchingStr == "" {
+			enableBatching = true // Default to enabled
+		} else {
+			enableBatching, _ = strconv.ParseBool(enableBatchingStr)
+		}
+	} else {
+		enableBatching = config.EnableBatching.ValueBool()
+	}
+
+	var batchTimeout int64
+	if config.BatchTimeout.IsNull() {
+		batchTimeoutStr := os.Getenv("IOSXR_BATCH_TIMEOUT")
+		if batchTimeoutStr == "" {
+			batchTimeout = 100 // Default 100ms
+		} else {
+			batchTimeout, _ = strconv.ParseInt(batchTimeoutStr, 10, 64)
+		}
+	} else {
+		batchTimeout = config.BatchTimeout.ValueInt64()
+	}
+
+	var batchMaxSize int64
+	if config.BatchMaxSize.IsNull() {
+		batchMaxSizeStr := os.Getenv("IOSXR_BATCH_MAX_SIZE")
+		if batchMaxSizeStr == "" {
+			batchMaxSize = 10 // Default 10 operations
+		} else {
+			batchMaxSize, _ = strconv.ParseInt(batchMaxSizeStr, 10, 64)
+		}
+	} else {
+		batchMaxSize = config.BatchMaxSize.ValueInt64()
+	}
+
 	client := client.NewClient(reuseConnection)
+
+	// Configure batching
+	client.EnableBatchingForAllDevices(enableBatching)
+	client.SetBatchTimeoutForAllDevices(time.Duration(batchTimeout) * time.Millisecond)
+	client.SetBatchMaxSizeForAllDevices(int(batchMaxSize))
 
 	err := client.AddTarget(ctx, "", host, username, password, certificate, key, caCertificate, verifyCertificate, tls)
 	if err != nil {

--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -23,7 +23,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -294,8 +296,8 @@ func (r *{{camelCase .Name}}Resource) Create(ctx context.Context, req resource.C
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -389,8 +391,8 @@ func (r *{{camelCase .Name}}Resource) Update(ctx context.Context, req resource.U
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -438,8 +440,8 @@ func (r *{{camelCase .Name}}Resource) Delete(ctx context.Context, req resource.D
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/client/batch_manager.go
+++ b/internal/provider/client/batch_manager.go
@@ -1,0 +1,290 @@
+// Copyright © 2023 Cisco Systems, Inc. and its affiliates.
+// All rights reserved.
+//
+// Licensed under the Mozilla Public License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://mozilla.org/MPL/2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: MPL-2.0
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/openconfig/gnmi/proto/gnmi"
+)
+
+// BatchOperation represents a single operation that can be batched
+type BatchOperation struct {
+	ResourceID string
+	Operation  SetOperation
+	ResultChan chan BatchResult
+}
+
+// BatchResult represents the result of a batched operation
+type BatchResult struct {
+	ResourceID string
+	Error      error
+	Response   *gnmi.SetResponse
+}
+
+// BatchManager manages batching of gNMI operations
+type BatchManager struct {
+	client          *Client
+	device          string
+	operations      []BatchOperation
+	mutex           sync.Mutex
+	batchTimeout    time.Duration
+	maxBatchSize    int
+	timer           *time.Timer
+	enabled         bool
+	processingBatch bool
+}
+
+// NewBatchManager creates a new batch manager for a specific device
+func NewBatchManager(client *Client, device string) *BatchManager {
+	return &BatchManager{
+		client:       client,
+		device:       device,
+		operations:   make([]BatchOperation, 0),
+		batchTimeout: 15 * time.Second, // Default 15s batch window
+		maxBatchSize: 500,              // Default max 100 operations per batch
+		enabled:      true,
+	}
+}
+
+// SetBatchTimeout sets the maximum time to wait before processing a batch
+func (bm *BatchManager) SetBatchTimeout(timeout time.Duration) {
+	bm.mutex.Lock()
+	defer bm.mutex.Unlock()
+	bm.batchTimeout = timeout
+}
+
+// SetMaxBatchSize sets the maximum number of operations in a batch
+func (bm *BatchManager) SetMaxBatchSize(size int) {
+	bm.mutex.Lock()
+	defer bm.mutex.Unlock()
+	bm.maxBatchSize = size
+}
+
+// EnableBatching enables or disables batching
+func (bm *BatchManager) EnableBatching(enabled bool) {
+	bm.mutex.Lock()
+	defer bm.mutex.Unlock()
+	bm.enabled = enabled
+	if !enabled && bm.timer != nil {
+		bm.timer.Stop()
+		bm.timer = nil
+	}
+}
+
+// AddOperation adds an operation to the batch
+func (bm *BatchManager) AddOperation(ctx context.Context, resourceID string, operation SetOperation) (*gnmi.SetResponse, error) {
+	if !bm.enabled {
+		// If batching is disabled, execute immediately
+		return bm.client.Set(ctx, bm.device, operation)
+	}
+
+	// Create result channel for this operation
+	resultChan := make(chan BatchResult, 1)
+	batchOp := BatchOperation{
+		ResourceID: resourceID,
+		Operation:  operation,
+		ResultChan: resultChan,
+	}
+
+	// Critical section for adding operation to batch
+	bm.mutex.Lock()
+	bm.operations = append(bm.operations, batchOp)
+	tflog.Debug(ctx, fmt.Sprintf("Added operation to batch for resource %s, batch size: %d", resourceID, len(bm.operations)))
+
+	shouldProcess := len(bm.operations) >= bm.maxBatchSize
+	shouldStartTimer := bm.timer == nil && !bm.processingBatch && len(bm.operations) == 1
+
+	if shouldProcess {
+		tflog.Debug(ctx, fmt.Sprintf("Batch size limit reached (%d), processing immediately", bm.maxBatchSize))
+		// Don't call processBatch in a goroutine while holding the lock
+		bm.processingBatch = true
+		if bm.timer != nil {
+			bm.timer.Stop()
+			bm.timer = nil
+		}
+		// Release lock before processing
+		bm.mutex.Unlock()
+		go bm.processBatchAsync(ctx)
+	} else if shouldStartTimer {
+		// Start timer for batch processing
+		bm.timer = time.AfterFunc(bm.batchTimeout, func() {
+			bm.processBatchAsync(ctx)
+		})
+		tflog.Debug(ctx, fmt.Sprintf("Started batch timer for %v", bm.batchTimeout))
+		bm.mutex.Unlock()
+	} else {
+		bm.mutex.Unlock()
+	}
+
+	// Wait for the result with a reasonable timeout
+	select {
+	case result := <-resultChan:
+		if result.Error != nil {
+			return nil, result.Error
+		}
+		return result.Response, nil
+	case <-time.After(30 * time.Second): // 30 second timeout
+		return nil, fmt.Errorf("batch operation timed out for resource %s", resourceID)
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// processBatchAsync is a wrapper to handle the async processing safely
+func (bm *BatchManager) processBatchAsync(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil {
+			tflog.Error(ctx, fmt.Sprintf("Panic in batch processing: %v", r))
+		}
+	}()
+	bm.processBatch(ctx)
+}
+
+// processBatch processes all accumulated operations in a single gNMI Set request
+func (bm *BatchManager) processBatch(ctx context.Context) {
+	bm.mutex.Lock()
+
+	// Double-check if we should process
+	if len(bm.operations) == 0 {
+		bm.processingBatch = false
+		bm.mutex.Unlock()
+		return
+	}
+
+	// If already processing, don't start another batch
+	if bm.processingBatch && bm.timer == nil {
+		bm.mutex.Unlock()
+		return
+	}
+
+	bm.processingBatch = true
+	operations := make([]BatchOperation, len(bm.operations))
+	copy(operations, bm.operations)
+	bm.operations = bm.operations[:0] // Clear the slice
+
+	// Stop and reset timer
+	if bm.timer != nil {
+		bm.timer.Stop()
+		bm.timer = nil
+	}
+	bm.mutex.Unlock()
+
+	tflog.Info(ctx, fmt.Sprintf("Processing batch of %d operations for device %s", len(operations), bm.device))
+
+	// Extract SetOperations for the gNMI client
+	setOps := make([]SetOperation, len(operations))
+	for i, batchOp := range operations {
+		setOps[i] = batchOp.Operation
+	}
+
+	// Execute the batched set operation with timeout context
+	batchCtx, cancel := context.WithTimeout(ctx, 25*time.Second)
+	defer cancel()
+
+	response, err := bm.client.Set(batchCtx, bm.device, setOps...)
+
+	// Send results to all waiting operations
+	for _, batchOp := range operations {
+		select {
+		case batchOp.ResultChan <- BatchResult{
+			ResourceID: batchOp.ResourceID,
+			Error:      err,
+			Response:   response,
+		}:
+		case <-time.After(5 * time.Second):
+			tflog.Error(ctx, fmt.Sprintf("Timeout sending result to resource %s", batchOp.ResourceID))
+		}
+		close(batchOp.ResultChan)
+	}
+
+	bm.mutex.Lock()
+	bm.processingBatch = false
+	bm.mutex.Unlock()
+
+	if err != nil {
+		tflog.Error(ctx, fmt.Sprintf("Batch operation failed: %v", err))
+	} else {
+		tflog.Info(ctx, fmt.Sprintf("Batch operation completed successfully for %d operations", len(operations)))
+	}
+}
+
+// Flush processes any pending operations immediately
+func (bm *BatchManager) Flush(ctx context.Context) {
+	bm.mutex.Lock()
+	defer bm.mutex.Unlock()
+
+	if len(bm.operations) > 0 {
+		tflog.Debug(ctx, fmt.Sprintf("Flushing %d pending operations", len(bm.operations)))
+		go bm.processBatch(ctx)
+	}
+}
+
+// GetPendingCount returns the number of pending operations
+func (bm *BatchManager) GetPendingCount() int {
+	bm.mutex.Lock()
+	defer bm.mutex.Unlock()
+	return len(bm.operations)
+}
+
+// Client-level batch management methods
+
+// EnableBatchingForAllDevices enables or disables batching globally for all devices
+func (c *Client) EnableBatchingForAllDevices(enabled bool) {
+	c.batchMutex.Lock()
+	defer c.batchMutex.Unlock()
+
+	c.BatchingEnabled = enabled
+	for _, bm := range c.batchManagers {
+		bm.EnableBatching(enabled)
+	}
+}
+
+// SetBatchTimeoutForAllDevices sets the batch timeout for all devices
+func (c *Client) SetBatchTimeoutForAllDevices(timeout time.Duration) {
+	c.batchMutex.Lock()
+	defer c.batchMutex.Unlock()
+
+	for _, bm := range c.batchManagers {
+		bm.SetBatchTimeout(timeout)
+	}
+}
+
+// SetBatchMaxSizeForAllDevices sets the maximum batch size for all devices
+func (c *Client) SetBatchMaxSizeForAllDevices(size int) {
+	c.batchMutex.Lock()
+	defer c.batchMutex.Unlock()
+
+	for _, bm := range c.batchManagers {
+		bm.SetMaxBatchSize(size)
+	}
+}
+
+// FlushBatchesForAllDevices flushes all pending batches for all devices
+func (c *Client) FlushBatchesForAllDevices(ctx context.Context) {
+	c.batchMutex.RLock()
+	defer c.batchMutex.RUnlock()
+
+	for _, bm := range c.batchManagers {
+		bm.Flush(ctx)
+	}
+}

--- a/internal/provider/resource_iosxr_as_path_set.go
+++ b/internal/provider/resource_iosxr_as_path_set.go
@@ -118,8 +118,8 @@ func (r *ASPathSetResource) Create(ctx context.Context, req resource.CreateReque
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -213,8 +213,8 @@ func (r *ASPathSetResource) Update(ctx context.Context, req resource.UpdateReque
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -250,8 +250,8 @@ func (r *ASPathSetResource) Delete(ctx context.Context, req resource.DeleteReque
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_banner.go
+++ b/internal/provider/resource_iosxr_banner.go
@@ -117,8 +117,8 @@ func (r *BannerResource) Create(ctx context.Context, req resource.CreateRequest,
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -212,8 +212,8 @@ func (r *BannerResource) Update(ctx context.Context, req resource.UpdateRequest,
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -249,8 +249,8 @@ func (r *BannerResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_bfd.go
+++ b/internal/provider/resource_iosxr_bfd.go
@@ -308,8 +308,8 @@ func (r *BFDResource) Create(ctx context.Context, req resource.CreateRequest, re
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -403,8 +403,8 @@ func (r *BFDResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -445,8 +445,8 @@ func (r *BFDResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_bgp_as_format.go
+++ b/internal/provider/resource_iosxr_bgp_as_format.go
@@ -109,8 +109,8 @@ func (r *BGPASFormatResource) Create(ctx context.Context, req resource.CreateReq
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -204,8 +204,8 @@ func (r *BGPASFormatResource) Update(ctx context.Context, req resource.UpdateReq
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -241,8 +241,8 @@ func (r *BGPASFormatResource) Delete(ctx context.Context, req resource.DeleteReq
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_cdp.go
+++ b/internal/provider/resource_iosxr_cdp.go
@@ -137,8 +137,8 @@ func (r *CDPResource) Create(ctx context.Context, req resource.CreateRequest, re
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -232,8 +232,8 @@ func (r *CDPResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -274,8 +274,8 @@ func (r *CDPResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_class_map_qos.go
+++ b/internal/provider/resource_iosxr_class_map_qos.go
@@ -142,8 +142,8 @@ func (r *ClassMapQoSResource) Create(ctx context.Context, req resource.CreateReq
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -237,8 +237,8 @@ func (r *ClassMapQoSResource) Update(ctx context.Context, req resource.UpdateReq
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -274,8 +274,8 @@ func (r *ClassMapQoSResource) Delete(ctx context.Context, req resource.DeleteReq
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_community_set.go
+++ b/internal/provider/resource_iosxr_community_set.go
@@ -118,8 +118,8 @@ func (r *CommunitySetResource) Create(ctx context.Context, req resource.CreateRe
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -213,8 +213,8 @@ func (r *CommunitySetResource) Update(ctx context.Context, req resource.UpdateRe
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -250,8 +250,8 @@ func (r *CommunitySetResource) Delete(ctx context.Context, req resource.DeleteRe
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_domain.go
+++ b/internal/provider/resource_iosxr_domain.go
@@ -225,8 +225,8 @@ func (r *DomainResource) Create(ctx context.Context, req resource.CreateRequest,
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -320,8 +320,8 @@ func (r *DomainResource) Update(ctx context.Context, req resource.UpdateRequest,
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -362,8 +362,8 @@ func (r *DomainResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_domain_vrf.go
+++ b/internal/provider/resource_iosxr_domain_vrf.go
@@ -232,8 +232,8 @@ func (r *DomainVRFResource) Create(ctx context.Context, req resource.CreateReque
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -327,8 +327,8 @@ func (r *DomainVRFResource) Update(ctx context.Context, req resource.UpdateReque
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -369,8 +369,8 @@ func (r *DomainVRFResource) Delete(ctx context.Context, req resource.DeleteReque
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_error_disable_recovery.go
+++ b/internal/provider/resource_iosxr_error_disable_recovery.go
@@ -251,8 +251,8 @@ func (r *ErrorDisableRecoveryResource) Create(ctx context.Context, req resource.
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -346,8 +346,8 @@ func (r *ErrorDisableRecoveryResource) Update(ctx context.Context, req resource.
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -388,8 +388,8 @@ func (r *ErrorDisableRecoveryResource) Delete(ctx context.Context, req resource.
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_esi_set.go
+++ b/internal/provider/resource_iosxr_esi_set.go
@@ -118,8 +118,8 @@ func (r *ESISetResource) Create(ctx context.Context, req resource.CreateRequest,
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -213,8 +213,8 @@ func (r *ESISetResource) Update(ctx context.Context, req resource.UpdateRequest,
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -250,8 +250,8 @@ func (r *ESISetResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_evpn.go
+++ b/internal/provider/resource_iosxr_evpn.go
@@ -118,8 +118,8 @@ func (r *EVPNResource) Create(ctx context.Context, req resource.CreateRequest, r
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -213,8 +213,8 @@ func (r *EVPNResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -255,8 +255,8 @@ func (r *EVPNResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_evpn_evi.go
+++ b/internal/provider/resource_iosxr_evpn_evi.go
@@ -354,8 +354,8 @@ func (r *EVPNEVIResource) Create(ctx context.Context, req resource.CreateRequest
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -449,8 +449,8 @@ func (r *EVPNEVIResource) Update(ctx context.Context, req resource.UpdateRequest
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -491,8 +491,8 @@ func (r *EVPNEVIResource) Delete(ctx context.Context, req resource.DeleteRequest
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_evpn_group.go
+++ b/internal/provider/resource_iosxr_evpn_group.go
@@ -139,8 +139,8 @@ func (r *EVPNGroupResource) Create(ctx context.Context, req resource.CreateReque
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -234,8 +234,8 @@ func (r *EVPNGroupResource) Update(ctx context.Context, req resource.UpdateReque
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -276,8 +276,8 @@ func (r *EVPNGroupResource) Delete(ctx context.Context, req resource.DeleteReque
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_evpn_interface.go
+++ b/internal/provider/resource_iosxr_evpn_interface.go
@@ -184,8 +184,8 @@ func (r *EVPNInterfaceResource) Create(ctx context.Context, req resource.CreateR
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -279,8 +279,8 @@ func (r *EVPNInterfaceResource) Update(ctx context.Context, req resource.UpdateR
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -321,8 +321,8 @@ func (r *EVPNInterfaceResource) Delete(ctx context.Context, req resource.DeleteR
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_evpn_segment_routing_srv6_evi.go
+++ b/internal/provider/resource_iosxr_evpn_segment_routing_srv6_evi.go
@@ -271,8 +271,8 @@ func (r *EVPNSegmentRoutingSRv6EVIResource) Create(ctx context.Context, req reso
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -366,8 +366,8 @@ func (r *EVPNSegmentRoutingSRv6EVIResource) Update(ctx context.Context, req reso
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -403,8 +403,8 @@ func (r *EVPNSegmentRoutingSRv6EVIResource) Delete(ctx context.Context, req reso
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_extcommunity_cost_set.go
+++ b/internal/provider/resource_iosxr_extcommunity_cost_set.go
@@ -118,8 +118,8 @@ func (r *ExtcommunityCostSetResource) Create(ctx context.Context, req resource.C
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -213,8 +213,8 @@ func (r *ExtcommunityCostSetResource) Update(ctx context.Context, req resource.U
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -250,8 +250,8 @@ func (r *ExtcommunityCostSetResource) Delete(ctx context.Context, req resource.D
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_extcommunity_opaque_set.go
+++ b/internal/provider/resource_iosxr_extcommunity_opaque_set.go
@@ -118,8 +118,8 @@ func (r *ExtcommunityOpaqueSetResource) Create(ctx context.Context, req resource
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -213,8 +213,8 @@ func (r *ExtcommunityOpaqueSetResource) Update(ctx context.Context, req resource
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -250,8 +250,8 @@ func (r *ExtcommunityOpaqueSetResource) Delete(ctx context.Context, req resource
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_extcommunity_rt_set.go
+++ b/internal/provider/resource_iosxr_extcommunity_rt_set.go
@@ -118,8 +118,8 @@ func (r *ExtcommunityRTSetResource) Create(ctx context.Context, req resource.Cre
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -213,8 +213,8 @@ func (r *ExtcommunityRTSetResource) Update(ctx context.Context, req resource.Upd
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -250,8 +250,8 @@ func (r *ExtcommunityRTSetResource) Delete(ctx context.Context, req resource.Del
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_extcommunity_soo_set.go
+++ b/internal/provider/resource_iosxr_extcommunity_soo_set.go
@@ -118,8 +118,8 @@ func (r *ExtcommunitySOOSetResource) Create(ctx context.Context, req resource.Cr
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -213,8 +213,8 @@ func (r *ExtcommunitySOOSetResource) Update(ctx context.Context, req resource.Up
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -250,8 +250,8 @@ func (r *ExtcommunitySOOSetResource) Delete(ctx context.Context, req resource.De
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_flow_exporter_map.go
+++ b/internal/provider/resource_iosxr_flow_exporter_map.go
@@ -229,8 +229,8 @@ func (r *FlowExporterMapResource) Create(ctx context.Context, req resource.Creat
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -324,8 +324,8 @@ func (r *FlowExporterMapResource) Update(ctx context.Context, req resource.Updat
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -361,8 +361,8 @@ func (r *FlowExporterMapResource) Delete(ctx context.Context, req resource.Delet
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_flow_monitor_map.go
+++ b/internal/provider/resource_iosxr_flow_monitor_map.go
@@ -373,8 +373,8 @@ func (r *FlowMonitorMapResource) Create(ctx context.Context, req resource.Create
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -468,8 +468,8 @@ func (r *FlowMonitorMapResource) Update(ctx context.Context, req resource.Update
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -505,8 +505,8 @@ func (r *FlowMonitorMapResource) Delete(ctx context.Context, req resource.Delete
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_flow_sampler_map.go
+++ b/internal/provider/resource_iosxr_flow_sampler_map.go
@@ -130,8 +130,8 @@ func (r *FlowSamplerMapResource) Create(ctx context.Context, req resource.Create
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -225,8 +225,8 @@ func (r *FlowSamplerMapResource) Update(ctx context.Context, req resource.Update
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -262,8 +262,8 @@ func (r *FlowSamplerMapResource) Delete(ctx context.Context, req resource.Delete
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_fpd.go
+++ b/internal/provider/resource_iosxr_fpd.go
@@ -126,8 +126,8 @@ func (r *FPDResource) Create(ctx context.Context, req resource.CreateRequest, re
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -221,8 +221,8 @@ func (r *FPDResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -263,8 +263,8 @@ func (r *FPDResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_hostname.go
+++ b/internal/provider/resource_iosxr_hostname.go
@@ -113,8 +113,8 @@ func (r *HostnameResource) Create(ctx context.Context, req resource.CreateReques
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -208,8 +208,8 @@ func (r *HostnameResource) Update(ctx context.Context, req resource.UpdateReques
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -245,8 +245,8 @@ func (r *HostnameResource) Delete(ctx context.Context, req resource.DeleteReques
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_interface.go
+++ b/internal/provider/resource_iosxr_interface.go
@@ -629,8 +629,8 @@ func (r *InterfaceResource) Create(ctx context.Context, req resource.CreateReque
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -724,8 +724,8 @@ func (r *InterfaceResource) Update(ctx context.Context, req resource.UpdateReque
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -766,8 +766,8 @@ func (r *InterfaceResource) Delete(ctx context.Context, req resource.DeleteReque
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_ipv4_access_list.go
+++ b/internal/provider/resource_iosxr_ipv4_access_list.go
@@ -1123,8 +1123,8 @@ func (r *IPv4AccessListResource) Create(ctx context.Context, req resource.Create
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -1218,8 +1218,8 @@ func (r *IPv4AccessListResource) Update(ctx context.Context, req resource.Update
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -1255,8 +1255,8 @@ func (r *IPv4AccessListResource) Delete(ctx context.Context, req resource.Delete
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_ipv4_access_list_options.go
+++ b/internal/provider/resource_iosxr_ipv4_access_list_options.go
@@ -129,8 +129,8 @@ func (r *IPv4AccessListOptionsResource) Create(ctx context.Context, req resource
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -224,8 +224,8 @@ func (r *IPv4AccessListOptionsResource) Update(ctx context.Context, req resource
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -266,8 +266,8 @@ func (r *IPv4AccessListOptionsResource) Delete(ctx context.Context, req resource
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_ipv4_prefix_list.go
+++ b/internal/provider/resource_iosxr_ipv4_prefix_list.go
@@ -182,8 +182,8 @@ func (r *IPv4PrefixListResource) Create(ctx context.Context, req resource.Create
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -277,8 +277,8 @@ func (r *IPv4PrefixListResource) Update(ctx context.Context, req resource.Update
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -314,8 +314,8 @@ func (r *IPv4PrefixListResource) Delete(ctx context.Context, req resource.Delete
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_ipv6.go
+++ b/internal/provider/resource_iosxr_ipv6.go
@@ -173,8 +173,8 @@ func (r *IPv6Resource) Create(ctx context.Context, req resource.CreateRequest, r
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -268,8 +268,8 @@ func (r *IPv6Resource) Update(ctx context.Context, req resource.UpdateRequest, r
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -310,8 +310,8 @@ func (r *IPv6Resource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_ipv6_access_list.go
+++ b/internal/provider/resource_iosxr_ipv6_access_list.go
@@ -963,8 +963,8 @@ func (r *IPv6AccessListResource) Create(ctx context.Context, req resource.Create
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -1058,8 +1058,8 @@ func (r *IPv6AccessListResource) Update(ctx context.Context, req resource.Update
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -1095,8 +1095,8 @@ func (r *IPv6AccessListResource) Delete(ctx context.Context, req resource.Delete
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_ipv6_access_list_options.go
+++ b/internal/provider/resource_iosxr_ipv6_access_list_options.go
@@ -129,8 +129,8 @@ func (r *IPv6AccessListOptionsResource) Create(ctx context.Context, req resource
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -224,8 +224,8 @@ func (r *IPv6AccessListOptionsResource) Update(ctx context.Context, req resource
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -266,8 +266,8 @@ func (r *IPv6AccessListOptionsResource) Delete(ctx context.Context, req resource
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_ipv6_prefix_list.go
+++ b/internal/provider/resource_iosxr_ipv6_prefix_list.go
@@ -182,8 +182,8 @@ func (r *IPv6PrefixListResource) Create(ctx context.Context, req resource.Create
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -277,8 +277,8 @@ func (r *IPv6PrefixListResource) Update(ctx context.Context, req resource.Update
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -314,8 +314,8 @@ func (r *IPv6PrefixListResource) Delete(ctx context.Context, req resource.Delete
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_key_chain.go
+++ b/internal/provider/resource_iosxr_key_chain.go
@@ -239,8 +239,8 @@ func (r *KeyChainResource) Create(ctx context.Context, req resource.CreateReques
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -334,8 +334,8 @@ func (r *KeyChainResource) Update(ctx context.Context, req resource.UpdateReques
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -371,8 +371,8 @@ func (r *KeyChainResource) Delete(ctx context.Context, req resource.DeleteReques
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_l2vpn.go
+++ b/internal/provider/resource_iosxr_l2vpn.go
@@ -150,8 +150,8 @@ func (r *L2VPNResource) Create(ctx context.Context, req resource.CreateRequest, 
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -245,8 +245,8 @@ func (r *L2VPNResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -287,8 +287,8 @@ func (r *L2VPNResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_l2vpn_bridge_group.go
+++ b/internal/provider/resource_iosxr_l2vpn_bridge_group.go
@@ -122,8 +122,8 @@ func (r *L2VPNBridgeGroupResource) Create(ctx context.Context, req resource.Crea
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -217,8 +217,8 @@ func (r *L2VPNBridgeGroupResource) Update(ctx context.Context, req resource.Upda
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -259,8 +259,8 @@ func (r *L2VPNBridgeGroupResource) Delete(ctx context.Context, req resource.Dele
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_l2vpn_bridge_group_bridge_domain.go
+++ b/internal/provider/resource_iosxr_l2vpn_bridge_group_bridge_domain.go
@@ -247,8 +247,8 @@ func (r *L2VPNBridgeGroupBridgeDomainResource) Create(ctx context.Context, req r
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -342,8 +342,8 @@ func (r *L2VPNBridgeGroupBridgeDomainResource) Update(ctx context.Context, req r
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -384,8 +384,8 @@ func (r *L2VPNBridgeGroupBridgeDomainResource) Delete(ctx context.Context, req r
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_l2vpn_pw_class.go
+++ b/internal/provider/resource_iosxr_l2vpn_pw_class.go
@@ -174,8 +174,8 @@ func (r *L2VPNPWClassResource) Create(ctx context.Context, req resource.CreateRe
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -269,8 +269,8 @@ func (r *L2VPNPWClassResource) Update(ctx context.Context, req resource.UpdateRe
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -311,8 +311,8 @@ func (r *L2VPNPWClassResource) Delete(ctx context.Context, req resource.DeleteRe
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_l2vpn_xconnect_group_p2p.go
+++ b/internal/provider/resource_iosxr_l2vpn_xconnect_group_p2p.go
@@ -317,8 +317,8 @@ func (r *L2VPNXconnectGroupP2PResource) Create(ctx context.Context, req resource
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -412,8 +412,8 @@ func (r *L2VPNXconnectGroupP2PResource) Update(ctx context.Context, req resource
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -454,8 +454,8 @@ func (r *L2VPNXconnectGroupP2PResource) Delete(ctx context.Context, req resource
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_lacp.go
+++ b/internal/provider/resource_iosxr_lacp.go
@@ -126,8 +126,8 @@ func (r *LACPResource) Create(ctx context.Context, req resource.CreateRequest, r
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -221,8 +221,8 @@ func (r *LACPResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -263,8 +263,8 @@ func (r *LACPResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_lldp.go
+++ b/internal/provider/resource_iosxr_lldp.go
@@ -168,8 +168,8 @@ func (r *LLDPResource) Create(ctx context.Context, req resource.CreateRequest, r
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -263,8 +263,8 @@ func (r *LLDPResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -305,8 +305,8 @@ func (r *LLDPResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_logging.go
+++ b/internal/provider/resource_iosxr_logging.go
@@ -181,8 +181,8 @@ func (r *LoggingResource) Create(ctx context.Context, req resource.CreateRequest
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -276,8 +276,8 @@ func (r *LoggingResource) Update(ctx context.Context, req resource.UpdateRequest
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -318,8 +318,8 @@ func (r *LoggingResource) Delete(ctx context.Context, req resource.DeleteRequest
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_logging_source_interface.go
+++ b/internal/provider/resource_iosxr_logging_source_interface.go
@@ -126,8 +126,8 @@ func (r *LoggingSourceInterfaceResource) Create(ctx context.Context, req resourc
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -221,8 +221,8 @@ func (r *LoggingSourceInterfaceResource) Update(ctx context.Context, req resourc
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -258,8 +258,8 @@ func (r *LoggingSourceInterfaceResource) Delete(ctx context.Context, req resourc
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_logging_vrf.go
+++ b/internal/provider/resource_iosxr_logging_vrf.go
@@ -194,8 +194,8 @@ func (r *LoggingVRFResource) Create(ctx context.Context, req resource.CreateRequ
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -289,8 +289,8 @@ func (r *LoggingVRFResource) Update(ctx context.Context, req resource.UpdateRequ
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -331,8 +331,8 @@ func (r *LoggingVRFResource) Delete(ctx context.Context, req resource.DeleteRequ
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_mpls_ldp.go
+++ b/internal/provider/resource_iosxr_mpls_ldp.go
@@ -236,8 +236,8 @@ func (r *MPLSLDPResource) Create(ctx context.Context, req resource.CreateRequest
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -331,8 +331,8 @@ func (r *MPLSLDPResource) Update(ctx context.Context, req resource.UpdateRequest
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -373,8 +373,8 @@ func (r *MPLSLDPResource) Delete(ctx context.Context, req resource.DeleteRequest
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_mpls_oam.go
+++ b/internal/provider/resource_iosxr_mpls_oam.go
@@ -137,8 +137,8 @@ func (r *MPLSOAMResource) Create(ctx context.Context, req resource.CreateRequest
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -232,8 +232,8 @@ func (r *MPLSOAMResource) Update(ctx context.Context, req resource.UpdateRequest
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -274,8 +274,8 @@ func (r *MPLSOAMResource) Delete(ctx context.Context, req resource.DeleteRequest
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_mpls_traffic_eng.go
+++ b/internal/provider/resource_iosxr_mpls_traffic_eng.go
@@ -114,8 +114,8 @@ func (r *MPLSTrafficEngResource) Create(ctx context.Context, req resource.Create
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -209,8 +209,8 @@ func (r *MPLSTrafficEngResource) Update(ctx context.Context, req resource.Update
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -251,8 +251,8 @@ func (r *MPLSTrafficEngResource) Delete(ctx context.Context, req resource.Delete
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_ntp.go
+++ b/internal/provider/resource_iosxr_ntp.go
@@ -910,8 +910,8 @@ func (r *NTPResource) Create(ctx context.Context, req resource.CreateRequest, re
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -1005,8 +1005,8 @@ func (r *NTPResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -1047,8 +1047,8 @@ func (r *NTPResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_pce.go
+++ b/internal/provider/resource_iosxr_pce.go
@@ -187,8 +187,8 @@ func (r *PCEResource) Create(ctx context.Context, req resource.CreateRequest, re
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -282,8 +282,8 @@ func (r *PCEResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -324,8 +324,8 @@ func (r *PCEResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_policy_map_qos.go
+++ b/internal/provider/resource_iosxr_policy_map_qos.go
@@ -239,8 +239,8 @@ func (r *PolicyMapQoSResource) Create(ctx context.Context, req resource.CreateRe
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -334,8 +334,8 @@ func (r *PolicyMapQoSResource) Update(ctx context.Context, req resource.UpdateRe
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -371,8 +371,8 @@ func (r *PolicyMapQoSResource) Delete(ctx context.Context, req resource.DeleteRe
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_prefix_set.go
+++ b/internal/provider/resource_iosxr_prefix_set.go
@@ -118,8 +118,8 @@ func (r *PrefixSetResource) Create(ctx context.Context, req resource.CreateReque
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -213,8 +213,8 @@ func (r *PrefixSetResource) Update(ctx context.Context, req resource.UpdateReque
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -250,8 +250,8 @@ func (r *PrefixSetResource) Delete(ctx context.Context, req resource.DeleteReque
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_rd_set.go
+++ b/internal/provider/resource_iosxr_rd_set.go
@@ -118,8 +118,8 @@ func (r *RDSetResource) Create(ctx context.Context, req resource.CreateRequest, 
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -213,8 +213,8 @@ func (r *RDSetResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -250,8 +250,8 @@ func (r *RDSetResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_route_policy.go
+++ b/internal/provider/resource_iosxr_route_policy.go
@@ -118,8 +118,8 @@ func (r *RoutePolicyResource) Create(ctx context.Context, req resource.CreateReq
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -213,8 +213,8 @@ func (r *RoutePolicyResource) Update(ctx context.Context, req resource.UpdateReq
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -250,8 +250,8 @@ func (r *RoutePolicyResource) Delete(ctx context.Context, req resource.DeleteReq
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_bgp.go
+++ b/internal/provider/resource_iosxr_router_bgp.go
@@ -393,8 +393,8 @@ func (r *RouterBGPResource) Create(ctx context.Context, req resource.CreateReque
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -488,8 +488,8 @@ func (r *RouterBGPResource) Update(ctx context.Context, req resource.UpdateReque
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -530,8 +530,8 @@ func (r *RouterBGPResource) Delete(ctx context.Context, req resource.DeleteReque
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_bgp_address_family.go
+++ b/internal/provider/resource_iosxr_router_bgp_address_family.go
@@ -404,8 +404,8 @@ func (r *RouterBGPAddressFamilyResource) Create(ctx context.Context, req resourc
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -499,8 +499,8 @@ func (r *RouterBGPAddressFamilyResource) Update(ctx context.Context, req resourc
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -541,8 +541,8 @@ func (r *RouterBGPAddressFamilyResource) Delete(ctx context.Context, req resourc
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_bgp_neighbor_address_family.go
+++ b/internal/provider/resource_iosxr_router_bgp_neighbor_address_family.go
@@ -229,8 +229,8 @@ func (r *RouterBGPNeighborAddressFamilyResource) Create(ctx context.Context, req
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -324,8 +324,8 @@ func (r *RouterBGPNeighborAddressFamilyResource) Update(ctx context.Context, req
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -366,8 +366,8 @@ func (r *RouterBGPNeighborAddressFamilyResource) Delete(ctx context.Context, req
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_bgp_neighbor_group.go
+++ b/internal/provider/resource_iosxr_router_bgp_neighbor_group.go
@@ -286,8 +286,8 @@ func (r *RouterBGPNeighborGroupResource) Create(ctx context.Context, req resourc
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -381,8 +381,8 @@ func (r *RouterBGPNeighborGroupResource) Update(ctx context.Context, req resourc
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -423,8 +423,8 @@ func (r *RouterBGPNeighborGroupResource) Delete(ctx context.Context, req resourc
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_bgp_vrf.go
+++ b/internal/provider/resource_iosxr_router_bgp_vrf.go
@@ -345,8 +345,8 @@ func (r *RouterBGPVRFResource) Create(ctx context.Context, req resource.CreateRe
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -440,8 +440,8 @@ func (r *RouterBGPVRFResource) Update(ctx context.Context, req resource.UpdateRe
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -482,8 +482,8 @@ func (r *RouterBGPVRFResource) Delete(ctx context.Context, req resource.DeleteRe
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_bgp_vrf_address_family.go
+++ b/internal/provider/resource_iosxr_router_bgp_vrf_address_family.go
@@ -354,8 +354,8 @@ func (r *RouterBGPVRFAddressFamilyResource) Create(ctx context.Context, req reso
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -449,8 +449,8 @@ func (r *RouterBGPVRFAddressFamilyResource) Update(ctx context.Context, req reso
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -491,8 +491,8 @@ func (r *RouterBGPVRFAddressFamilyResource) Delete(ctx context.Context, req reso
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_bgp_vrf_neighbor_address_family.go
+++ b/internal/provider/resource_iosxr_router_bgp_vrf_neighbor_address_family.go
@@ -219,8 +219,8 @@ func (r *RouterBGPVRFNeighborAddressFamilyResource) Create(ctx context.Context, 
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -314,8 +314,8 @@ func (r *RouterBGPVRFNeighborAddressFamilyResource) Update(ctx context.Context, 
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -356,8 +356,8 @@ func (r *RouterBGPVRFNeighborAddressFamilyResource) Delete(ctx context.Context, 
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_hsrp_interface.go
+++ b/internal/provider/resource_iosxr_router_hsrp_interface.go
@@ -165,8 +165,8 @@ func (r *RouterHSRPInterfaceResource) Create(ctx context.Context, req resource.C
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -260,8 +260,8 @@ func (r *RouterHSRPInterfaceResource) Update(ctx context.Context, req resource.U
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -302,8 +302,8 @@ func (r *RouterHSRPInterfaceResource) Delete(ctx context.Context, req resource.D
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_hsrp_interface_ipv4_group_v1.go
+++ b/internal/provider/resource_iosxr_router_hsrp_interface_ipv4_group_v1.go
@@ -279,8 +279,8 @@ func (r *RouterHSRPInterfaceIPv4GroupV1Resource) Create(ctx context.Context, req
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -374,8 +374,8 @@ func (r *RouterHSRPInterfaceIPv4GroupV1Resource) Update(ctx context.Context, req
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -416,8 +416,8 @@ func (r *RouterHSRPInterfaceIPv4GroupV1Resource) Delete(ctx context.Context, req
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_hsrp_interface_ipv4_group_v2.go
+++ b/internal/provider/resource_iosxr_router_hsrp_interface_ipv4_group_v2.go
@@ -279,8 +279,8 @@ func (r *RouterHSRPInterfaceIPv4GroupV2Resource) Create(ctx context.Context, req
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -374,8 +374,8 @@ func (r *RouterHSRPInterfaceIPv4GroupV2Resource) Update(ctx context.Context, req
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -416,8 +416,8 @@ func (r *RouterHSRPInterfaceIPv4GroupV2Resource) Delete(ctx context.Context, req
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_hsrp_interface_ipv6_group_v2.go
+++ b/internal/provider/resource_iosxr_router_hsrp_interface_ipv6_group_v2.go
@@ -286,8 +286,8 @@ func (r *RouterHSRPInterfaceIPv6GroupV2Resource) Create(ctx context.Context, req
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -381,8 +381,8 @@ func (r *RouterHSRPInterfaceIPv6GroupV2Resource) Update(ctx context.Context, req
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -423,8 +423,8 @@ func (r *RouterHSRPInterfaceIPv6GroupV2Resource) Delete(ctx context.Context, req
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_isis.go
+++ b/internal/provider/resource_iosxr_router_isis.go
@@ -404,8 +404,8 @@ func (r *RouterISISResource) Create(ctx context.Context, req resource.CreateRequ
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -499,8 +499,8 @@ func (r *RouterISISResource) Update(ctx context.Context, req resource.UpdateRequ
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -541,8 +541,8 @@ func (r *RouterISISResource) Delete(ctx context.Context, req resource.DeleteRequ
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_isis_address_family.go
+++ b/internal/provider/resource_iosxr_router_isis_address_family.go
@@ -402,8 +402,8 @@ func (r *RouterISISAddressFamilyResource) Create(ctx context.Context, req resour
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -497,8 +497,8 @@ func (r *RouterISISAddressFamilyResource) Update(ctx context.Context, req resour
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -539,8 +539,8 @@ func (r *RouterISISAddressFamilyResource) Delete(ctx context.Context, req resour
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_isis_interface.go
+++ b/internal/provider/resource_iosxr_router_isis_interface.go
@@ -195,8 +195,8 @@ func (r *RouterISISInterfaceResource) Create(ctx context.Context, req resource.C
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -290,8 +290,8 @@ func (r *RouterISISInterfaceResource) Update(ctx context.Context, req resource.U
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -332,8 +332,8 @@ func (r *RouterISISInterfaceResource) Delete(ctx context.Context, req resource.D
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_isis_interface_address_family.go
+++ b/internal/provider/resource_iosxr_router_isis_interface_address_family.go
@@ -255,8 +255,8 @@ func (r *RouterISISInterfaceAddressFamilyResource) Create(ctx context.Context, r
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -350,8 +350,8 @@ func (r *RouterISISInterfaceAddressFamilyResource) Update(ctx context.Context, r
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -392,8 +392,8 @@ func (r *RouterISISInterfaceAddressFamilyResource) Delete(ctx context.Context, r
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_ospf.go
+++ b/internal/provider/resource_iosxr_router_ospf.go
@@ -380,8 +380,8 @@ func (r *RouterOSPFResource) Create(ctx context.Context, req resource.CreateRequ
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -475,8 +475,8 @@ func (r *RouterOSPFResource) Update(ctx context.Context, req resource.UpdateRequ
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -517,8 +517,8 @@ func (r *RouterOSPFResource) Delete(ctx context.Context, req resource.DeleteRequ
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_ospf_area_interface.go
+++ b/internal/provider/resource_iosxr_router_ospf_area_interface.go
@@ -248,8 +248,8 @@ func (r *RouterOSPFAreaInterfaceResource) Create(ctx context.Context, req resour
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -343,8 +343,8 @@ func (r *RouterOSPFAreaInterfaceResource) Update(ctx context.Context, req resour
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -385,8 +385,8 @@ func (r *RouterOSPFAreaInterfaceResource) Delete(ctx context.Context, req resour
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_ospf_vrf.go
+++ b/internal/provider/resource_iosxr_router_ospf_vrf.go
@@ -383,8 +383,8 @@ func (r *RouterOSPFVRFResource) Create(ctx context.Context, req resource.CreateR
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -478,8 +478,8 @@ func (r *RouterOSPFVRFResource) Update(ctx context.Context, req resource.UpdateR
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -520,8 +520,8 @@ func (r *RouterOSPFVRFResource) Delete(ctx context.Context, req resource.DeleteR
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_ospf_vrf_area_interface.go
+++ b/internal/provider/resource_iosxr_router_ospf_vrf_area_interface.go
@@ -189,8 +189,8 @@ func (r *RouterOSPFVRFAreaInterfaceResource) Create(ctx context.Context, req res
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -284,8 +284,8 @@ func (r *RouterOSPFVRFAreaInterfaceResource) Update(ctx context.Context, req res
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -326,8 +326,8 @@ func (r *RouterOSPFVRFAreaInterfaceResource) Delete(ctx context.Context, req res
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_static_ipv4_multicast.go
+++ b/internal/provider/resource_iosxr_router_static_ipv4_multicast.go
@@ -499,8 +499,8 @@ func (r *RouterStaticIPv4MulticastResource) Create(ctx context.Context, req reso
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -594,8 +594,8 @@ func (r *RouterStaticIPv4MulticastResource) Update(ctx context.Context, req reso
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -636,8 +636,8 @@ func (r *RouterStaticIPv4MulticastResource) Delete(ctx context.Context, req reso
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_static_ipv4_unicast.go
+++ b/internal/provider/resource_iosxr_router_static_ipv4_unicast.go
@@ -499,8 +499,8 @@ func (r *RouterStaticIPv4UnicastResource) Create(ctx context.Context, req resour
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -594,8 +594,8 @@ func (r *RouterStaticIPv4UnicastResource) Update(ctx context.Context, req resour
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -636,8 +636,8 @@ func (r *RouterStaticIPv4UnicastResource) Delete(ctx context.Context, req resour
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_static_ipv6_multicast.go
+++ b/internal/provider/resource_iosxr_router_static_ipv6_multicast.go
@@ -504,8 +504,8 @@ func (r *RouterStaticIPv6MulticastResource) Create(ctx context.Context, req reso
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -599,8 +599,8 @@ func (r *RouterStaticIPv6MulticastResource) Update(ctx context.Context, req reso
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -641,8 +641,8 @@ func (r *RouterStaticIPv6MulticastResource) Delete(ctx context.Context, req reso
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_static_ipv6_unicast.go
+++ b/internal/provider/resource_iosxr_router_static_ipv6_unicast.go
@@ -504,8 +504,8 @@ func (r *RouterStaticIPv6UnicastResource) Create(ctx context.Context, req resour
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -599,8 +599,8 @@ func (r *RouterStaticIPv6UnicastResource) Update(ctx context.Context, req resour
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -641,8 +641,8 @@ func (r *RouterStaticIPv6UnicastResource) Delete(ctx context.Context, req resour
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_static_vrf_ipv4_multicast.go
+++ b/internal/provider/resource_iosxr_router_static_vrf_ipv4_multicast.go
@@ -524,8 +524,8 @@ func (r *RouterStaticVRFIPv4MulticastResource) Create(ctx context.Context, req r
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -619,8 +619,8 @@ func (r *RouterStaticVRFIPv4MulticastResource) Update(ctx context.Context, req r
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -661,8 +661,8 @@ func (r *RouterStaticVRFIPv4MulticastResource) Delete(ctx context.Context, req r
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_static_vrf_ipv4_unicast.go
+++ b/internal/provider/resource_iosxr_router_static_vrf_ipv4_unicast.go
@@ -524,8 +524,8 @@ func (r *RouterStaticVRFIPv4UnicastResource) Create(ctx context.Context, req res
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -619,8 +619,8 @@ func (r *RouterStaticVRFIPv4UnicastResource) Update(ctx context.Context, req res
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -661,8 +661,8 @@ func (r *RouterStaticVRFIPv4UnicastResource) Delete(ctx context.Context, req res
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_static_vrf_ipv6_multicast.go
+++ b/internal/provider/resource_iosxr_router_static_vrf_ipv6_multicast.go
@@ -529,8 +529,8 @@ func (r *RouterStaticVRFIPv6MulticastResource) Create(ctx context.Context, req r
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -624,8 +624,8 @@ func (r *RouterStaticVRFIPv6MulticastResource) Update(ctx context.Context, req r
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -666,8 +666,8 @@ func (r *RouterStaticVRFIPv6MulticastResource) Delete(ctx context.Context, req r
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_static_vrf_ipv6_unicast.go
+++ b/internal/provider/resource_iosxr_router_static_vrf_ipv6_unicast.go
@@ -529,8 +529,8 @@ func (r *RouterStaticVRFIPv6UnicastResource) Create(ctx context.Context, req res
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -624,8 +624,8 @@ func (r *RouterStaticVRFIPv6UnicastResource) Update(ctx context.Context, req res
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -666,8 +666,8 @@ func (r *RouterStaticVRFIPv6UnicastResource) Delete(ctx context.Context, req res
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_vrrp_interface.go
+++ b/internal/provider/resource_iosxr_router_vrrp_interface.go
@@ -157,8 +157,8 @@ func (r *RouterVRRPInterfaceResource) Create(ctx context.Context, req resource.C
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -252,8 +252,8 @@ func (r *RouterVRRPInterfaceResource) Update(ctx context.Context, req resource.U
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -294,8 +294,8 @@ func (r *RouterVRRPInterfaceResource) Delete(ctx context.Context, req resource.D
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_vrrp_interface_ipv4.go
+++ b/internal/provider/resource_iosxr_router_vrrp_interface_ipv4.go
@@ -277,8 +277,8 @@ func (r *RouterVRRPInterfaceIPv4Resource) Create(ctx context.Context, req resour
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -372,8 +372,8 @@ func (r *RouterVRRPInterfaceIPv4Resource) Update(ctx context.Context, req resour
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -414,8 +414,8 @@ func (r *RouterVRRPInterfaceIPv4Resource) Delete(ctx context.Context, req resour
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_router_vrrp_interface_ipv6.go
+++ b/internal/provider/resource_iosxr_router_vrrp_interface_ipv6.go
@@ -258,8 +258,8 @@ func (r *RouterVRRPInterfaceIPv6Resource) Create(ctx context.Context, req resour
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -353,8 +353,8 @@ func (r *RouterVRRPInterfaceIPv6Resource) Update(ctx context.Context, req resour
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -395,8 +395,8 @@ func (r *RouterVRRPInterfaceIPv6Resource) Delete(ctx context.Context, req resour
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_segment_routing.go
+++ b/internal/provider/resource_iosxr_segment_routing.go
@@ -139,8 +139,8 @@ func (r *SegmentRoutingResource) Create(ctx context.Context, req resource.Create
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -234,8 +234,8 @@ func (r *SegmentRoutingResource) Update(ctx context.Context, req resource.Update
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -276,8 +276,8 @@ func (r *SegmentRoutingResource) Delete(ctx context.Context, req resource.Delete
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_segment_routing_te.go
+++ b/internal/provider/resource_iosxr_segment_routing_te.go
@@ -341,8 +341,8 @@ func (r *SegmentRoutingTEResource) Create(ctx context.Context, req resource.Crea
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -436,8 +436,8 @@ func (r *SegmentRoutingTEResource) Update(ctx context.Context, req resource.Upda
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -478,8 +478,8 @@ func (r *SegmentRoutingTEResource) Delete(ctx context.Context, req resource.Dele
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_segment_routing_te_policy_candidate_path.go
+++ b/internal/provider/resource_iosxr_segment_routing_te_policy_candidate_path.go
@@ -176,8 +176,8 @@ func (r *SegmentRoutingTEPolicyCandidatePathResource) Create(ctx context.Context
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -271,8 +271,8 @@ func (r *SegmentRoutingTEPolicyCandidatePathResource) Update(ctx context.Context
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -313,8 +313,8 @@ func (r *SegmentRoutingTEPolicyCandidatePathResource) Delete(ctx context.Context
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_segment_routing_v6.go
+++ b/internal/provider/resource_iosxr_segment_routing_v6.go
@@ -158,8 +158,8 @@ func (r *SegmentRoutingV6Resource) Create(ctx context.Context, req resource.Crea
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -253,8 +253,8 @@ func (r *SegmentRoutingV6Resource) Update(ctx context.Context, req resource.Upda
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -295,8 +295,8 @@ func (r *SegmentRoutingV6Resource) Delete(ctx context.Context, req resource.Dele
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_service_timestamps.go
+++ b/internal/provider/resource_iosxr_service_timestamps.go
@@ -157,8 +157,8 @@ func (r *ServiceTimestampsResource) Create(ctx context.Context, req resource.Cre
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -252,8 +252,8 @@ func (r *ServiceTimestampsResource) Update(ctx context.Context, req resource.Upd
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -289,8 +289,8 @@ func (r *ServiceTimestampsResource) Delete(ctx context.Context, req resource.Del
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_snmp_server.go
+++ b/internal/provider/resource_iosxr_snmp_server.go
@@ -591,8 +591,8 @@ func (r *SNMPServerResource) Create(ctx context.Context, req resource.CreateRequ
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -686,8 +686,8 @@ func (r *SNMPServerResource) Update(ctx context.Context, req resource.UpdateRequ
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -728,8 +728,8 @@ func (r *SNMPServerResource) Delete(ctx context.Context, req resource.DeleteRequ
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_snmp_server_mib.go
+++ b/internal/provider/resource_iosxr_snmp_server_mib.go
@@ -118,8 +118,8 @@ func (r *SNMPServerMIBResource) Create(ctx context.Context, req resource.CreateR
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -213,8 +213,8 @@ func (r *SNMPServerMIBResource) Update(ctx context.Context, req resource.UpdateR
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -255,8 +255,8 @@ func (r *SNMPServerMIBResource) Delete(ctx context.Context, req resource.DeleteR
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_snmp_server_view.go
+++ b/internal/provider/resource_iosxr_snmp_server_view.go
@@ -145,8 +145,8 @@ func (r *SNMPServerViewResource) Create(ctx context.Context, req resource.Create
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -240,8 +240,8 @@ func (r *SNMPServerViewResource) Update(ctx context.Context, req resource.Update
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -282,8 +282,8 @@ func (r *SNMPServerViewResource) Delete(ctx context.Context, req resource.Delete
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_snmp_server_vrf_host.go
+++ b/internal/provider/resource_iosxr_snmp_server_vrf_host.go
@@ -158,8 +158,8 @@ func (r *SNMPServerVRFHostResource) Create(ctx context.Context, req resource.Cre
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -253,8 +253,8 @@ func (r *SNMPServerVRFHostResource) Update(ctx context.Context, req resource.Upd
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -295,8 +295,8 @@ func (r *SNMPServerVRFHostResource) Delete(ctx context.Context, req resource.Del
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_ssh.go
+++ b/internal/provider/resource_iosxr_ssh.go
@@ -171,8 +171,8 @@ func (r *SSHResource) Create(ctx context.Context, req resource.CreateRequest, re
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -266,8 +266,8 @@ func (r *SSHResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -308,8 +308,8 @@ func (r *SSHResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_tag_set.go
+++ b/internal/provider/resource_iosxr_tag_set.go
@@ -118,8 +118,8 @@ func (r *TagSetResource) Create(ctx context.Context, req resource.CreateRequest,
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -213,8 +213,8 @@ func (r *TagSetResource) Update(ctx context.Context, req resource.UpdateRequest,
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -250,8 +250,8 @@ func (r *TagSetResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_telnet.go
+++ b/internal/provider/resource_iosxr_telnet.go
@@ -187,8 +187,8 @@ func (r *TelnetResource) Create(ctx context.Context, req resource.CreateRequest,
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -282,8 +282,8 @@ func (r *TelnetResource) Update(ctx context.Context, req resource.UpdateRequest,
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -324,8 +324,8 @@ func (r *TelnetResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}

--- a/internal/provider/resource_iosxr_vrf.go
+++ b/internal/provider/resource_iosxr_vrf.go
@@ -542,8 +542,8 @@ func (r *VRFResource) Create(ctx context.Context, req resource.CreateRequest, re
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.getPath(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -637,8 +637,8 @@ func (r *VRFResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		ops = append(ops, client.SetOperation{Path: i, Body: "", Operation: client.Delete})
 	}
 
-	_, err := r.client.Set(ctx, plan.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, plan.Device.ValueString(), plan.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}
@@ -679,8 +679,8 @@ func (r *VRFResource) Delete(ctx context.Context, req resource.DeleteRequest, re
 		}
 	}
 
-	_, err := r.client.Set(ctx, state.Device.ValueString(), ops...)
-	if err != nil {
+	// Execute operations using the centralized batching logic
+	if err := r.client.ExecuteOperations(ctx, state.Device.ValueString(), state.Id.ValueString(), ops); err != nil {
 		resp.Diagnostics.AddError("Unable to apply gNMI Set operation", err.Error())
 		return
 	}


### PR DESCRIPTION
A single consolidated request is sent to the device containing the full configuration diff.
The device either accepts the entire request or rejects it , so no partial state .

the provider is now support these new features :
  # Batch configuration - allow multiple resources to be batched together
  enable_batching    = true
  batch_timeout      = 10   # 1 second batch window to catch all sequential operations
  batch_max_size     = 100     # Allow up to 10 operations to be batched together