### PR TITLE
feat: add l2transport to interface_bundle_ether_subinterface

### DIFF
--- a/docs/data-sources/interface_bundle_ether_subinterface.md
+++ b/docs/data-sources/interface_bundle_ether_subinterface.md
@@ -122,6 +122,7 @@ data "iosxr_interface_bundle_ether_subinterface" "example" {
 - `ipv6_verify_unicast_source_reachable_via_allow_default` (Boolean) Allow default route to match when checking source address
 - `ipv6_verify_unicast_source_reachable_via_allow_self_ping` (Boolean) Allow router to ping itself (opens vulnerability in verification)
 - `ipv6_verify_unicast_source_reachable_via_type` (String) Source reachable type
+- `l2transport` (Boolean) l2transport sub-interface
 - `l2transport_encapsulation_dot1q_second_dot1q` (String) Single VLAN id or start of VLAN range
 - `l2transport_encapsulation_dot1q_vlan_id` (String) Single VLAN id or start of VLAN range
 - `lldp` (Boolean) LLDP interface configuration commands

--- a/docs/resources/interface_bundle_ether_subinterface.md
+++ b/docs/resources/interface_bundle_ether_subinterface.md
@@ -15,6 +15,7 @@ This resource can manage the Interface Bundle Ether Subinterface configuration.
 ```terraform
 resource "iosxr_interface_bundle_ether_subinterface" "example" {
   name                         = "100.100"
+  l2transport                  = false
   point_to_point               = false
   multipoint                   = false
   dampening                    = true
@@ -385,6 +386,7 @@ resource "iosxr_interface_bundle_ether_subinterface" "example" {
 - `ipv6_verify_unicast_source_reachable_via_allow_self_ping` (Boolean) Allow router to ping itself (opens vulnerability in verification)
 - `ipv6_verify_unicast_source_reachable_via_type` (String) Source reachable type
   - Choices: `any`, `rx`
+- `l2transport` (Boolean) l2transport sub-interface
 - `l2transport_encapsulation_dot1q_second_dot1q` (String) Single VLAN id or start of VLAN range
 - `l2transport_encapsulation_dot1q_vlan_id` (String) Single VLAN id or start of VLAN range
 - `lldp` (Boolean) LLDP interface configuration commands

--- a/examples/resources/iosxr_interface_bundle_ether_subinterface/resource.tf
+++ b/examples/resources/iosxr_interface_bundle_ether_subinterface/resource.tf
@@ -1,5 +1,6 @@
 resource "iosxr_interface_bundle_ether_subinterface" "example" {
   name                         = "100.100"
+  l2transport                  = false
   point_to_point               = false
   multipoint                   = false
   dampening                    = true

--- a/gen/definitions/interface_bundle_ether_subinterface.yaml
+++ b/gen/definitions/interface_bundle_ether_subinterface.yaml
@@ -11,6 +11,9 @@ attributes:
     string_patterns:
       - '^[0-9]+\.[0-9]+$'
     example: "100.100"
+  - yang_name: sub-interface-type/l2transport
+    tf_name: l2transport
+    example: false
   - yang_name: sub-interface-type/point-to-point
     tf_name: point_to_point
     example: false

--- a/internal/provider/data_source_iosxr_interface_bundle_ether_subinterface.go
+++ b/internal/provider/data_source_iosxr_interface_bundle_ether_subinterface.go
@@ -71,6 +71,10 @@ func (d *InterfaceBundleEtherSubinterfaceDataSource) Schema(ctx context.Context,
 				MarkdownDescription: "Bundle-Ether subinterface ID",
 				Required:            true,
 			},
+			"l2transport": schema.BoolAttribute{
+				MarkdownDescription: "l2transport sub-interface",
+				Computed:            true,
+			},
 			"point_to_point": schema.BoolAttribute{
 				MarkdownDescription: "point-to-point sub-interface",
 				Computed:            true,

--- a/internal/provider/data_source_iosxr_interface_bundle_ether_subinterface_test.go
+++ b/internal/provider/data_source_iosxr_interface_bundle_ether_subinterface_test.go
@@ -33,6 +33,7 @@ import (
 
 func TestAccDataSourceIosxrInterfaceBundleEtherSubinterface(t *testing.T) {
 	var checks []resource.TestCheckFunc
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_interface_bundle_ether_subinterface.test", "l2transport", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_interface_bundle_ether_subinterface.test", "point_to_point", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_interface_bundle_ether_subinterface.test", "multipoint", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_interface_bundle_ether_subinterface.test", "dampening", "true"))
@@ -486,6 +487,7 @@ func testAccDataSourceIosxrInterfaceBundleEtherSubinterfaceConfig() string {
 	config := `resource "iosxr_interface_bundle_ether_subinterface" "test" {` + "\n"
 	config += `	delete_mode = "attributes"` + "\n"
 	config += `	name = "100.100"` + "\n"
+	config += `	l2transport = false` + "\n"
 	config += `	point_to_point = false` + "\n"
 	config += `	multipoint = false` + "\n"
 	config += `	dampening = true` + "\n"

--- a/internal/provider/model_iosxr_interface_bundle_ether_subinterface.go
+++ b/internal/provider/model_iosxr_interface_bundle_ether_subinterface.go
@@ -39,6 +39,7 @@ type InterfaceBundleEtherSubinterface struct {
 	Id                                                 types.String                                                                    `tfsdk:"id"`
 	DeleteMode                                         types.String                                                                    `tfsdk:"delete_mode"`
 	Name                                               types.String                                                                    `tfsdk:"name"`
+	L2transport                                        types.Bool                                                                      `tfsdk:"l2transport"`
 	PointToPoint                                       types.Bool                                                                      `tfsdk:"point_to_point"`
 	Multipoint                                         types.Bool                                                                      `tfsdk:"multipoint"`
 	Dampening                                          types.Bool                                                                      `tfsdk:"dampening"`
@@ -222,6 +223,7 @@ type InterfaceBundleEtherSubinterfaceData struct {
 	Device                                             types.String                                                                    `tfsdk:"device"`
 	Id                                                 types.String                                                                    `tfsdk:"id"`
 	Name                                               types.String                                                                    `tfsdk:"name"`
+	L2transport                                        types.Bool                                                                      `tfsdk:"l2transport"`
 	PointToPoint                                       types.Bool                                                                      `tfsdk:"point_to_point"`
 	Multipoint                                         types.Bool                                                                      `tfsdk:"multipoint"`
 	Dampening                                          types.Bool                                                                      `tfsdk:"dampening"`
@@ -561,6 +563,11 @@ func (data InterfaceBundleEtherSubinterface) toBody(ctx context.Context) string 
 	body := "{}"
 	if !data.Name.IsNull() && !data.Name.IsUnknown() {
 		body, _ = sjson.Set(body, "", data.Name.ValueString())
+	}
+	if !data.L2transport.IsNull() && !data.L2transport.IsUnknown() {
+		if data.L2transport.ValueBool() {
+			body, _ = sjson.Set(body, "sub-interface-type.l2transport", map[string]string{})
+		}
 	}
 	if !data.PointToPoint.IsNull() && !data.PointToPoint.IsUnknown() {
 		if data.PointToPoint.ValueBool() {
@@ -1597,6 +1604,15 @@ func (data InterfaceBundleEtherSubinterface) toBody(ctx context.Context) string 
 // Section below is generated&owned by "gen/generator.go". //template:begin updateFromBody
 
 func (data *InterfaceBundleEtherSubinterface) updateFromBody(ctx context.Context, res []byte) {
+	if value := gjson.GetBytes(res, "sub-interface-type.l2transport"); !data.L2transport.IsNull() {
+		if value.Exists() {
+			data.L2transport = types.BoolValue(true)
+		} else {
+			data.L2transport = types.BoolValue(false)
+		}
+	} else {
+		data.L2transport = types.BoolNull()
+	}
 	if value := gjson.GetBytes(res, "sub-interface-type.point-to-point"); !data.PointToPoint.IsNull() {
 		if value.Exists() {
 			data.PointToPoint = types.BoolValue(true)
@@ -3774,6 +3790,11 @@ func (data *InterfaceBundleEtherSubinterface) updateFromBody(ctx context.Context
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBody
 
 func (data *InterfaceBundleEtherSubinterface) fromBody(ctx context.Context, res []byte) {
+	if value := gjson.GetBytes(res, "sub-interface-type.l2transport"); value.Exists() {
+		data.L2transport = types.BoolValue(true)
+	} else {
+		data.L2transport = types.BoolValue(false)
+	}
 	if value := gjson.GetBytes(res, "sub-interface-type.point-to-point"); value.Exists() {
 		data.PointToPoint = types.BoolValue(true)
 	} else {
@@ -4891,6 +4912,11 @@ func (data *InterfaceBundleEtherSubinterface) fromBody(ctx context.Context, res 
 // Section below is generated&owned by "gen/generator.go". //template:begin fromBodyData
 
 func (data *InterfaceBundleEtherSubinterfaceData) fromBody(ctx context.Context, res []byte) {
+	if value := gjson.GetBytes(res, "sub-interface-type.l2transport"); value.Exists() {
+		data.L2transport = types.BoolValue(true)
+	} else {
+		data.L2transport = types.BoolValue(false)
+	}
 	if value := gjson.GetBytes(res, "sub-interface-type.point-to-point"); value.Exists() {
 		data.PointToPoint = types.BoolValue(true)
 	} else {
@@ -7422,6 +7448,9 @@ func (data *InterfaceBundleEtherSubinterface) getDeletedItems(ctx context.Contex
 	if !state.PointToPoint.IsNull() && data.PointToPoint.IsNull() {
 		deletedItems = append(deletedItems, fmt.Sprintf("%v/sub-interface-type/point-to-point", state.getPath()))
 	}
+	if !state.L2transport.IsNull() && data.L2transport.IsNull() {
+		deletedItems = append(deletedItems, fmt.Sprintf("%v/sub-interface-type/l2transport", state.getPath()))
+	}
 	return deletedItems
 }
 
@@ -7894,6 +7923,9 @@ func (data *InterfaceBundleEtherSubinterface) getEmptyLeafsDelete(ctx context.Co
 	}
 	if !data.PointToPoint.IsNull() && !data.PointToPoint.ValueBool() {
 		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/sub-interface-type/point-to-point", data.getPath()))
+	}
+	if !data.L2transport.IsNull() && !data.L2transport.ValueBool() {
+		emptyLeafsDelete = append(emptyLeafsDelete, fmt.Sprintf("%v/sub-interface-type/l2transport", data.getPath()))
 	}
 	return emptyLeafsDelete
 }
@@ -8586,6 +8618,9 @@ func (data *InterfaceBundleEtherSubinterface) getDeletePaths(ctx context.Context
 	}
 	if !data.PointToPoint.IsNull() {
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/sub-interface-type/point-to-point", data.getPath()))
+	}
+	if !data.L2transport.IsNull() {
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/sub-interface-type/l2transport", data.getPath()))
 	}
 	return deletePaths
 }

--- a/internal/provider/resource_iosxr_interface_bundle_ether_subinterface.go
+++ b/internal/provider/resource_iosxr_interface_bundle_ether_subinterface.go
@@ -91,6 +91,10 @@ func (r *InterfaceBundleEtherSubinterfaceResource) Schema(ctx context.Context, r
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
+			"l2transport": schema.BoolAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("l2transport sub-interface").String,
+				Optional:            true,
+			},
 			"point_to_point": schema.BoolAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("point-to-point sub-interface").String,
 				Optional:            true,

--- a/internal/provider/resource_iosxr_interface_bundle_ether_subinterface_test.go
+++ b/internal/provider/resource_iosxr_interface_bundle_ether_subinterface_test.go
@@ -36,6 +36,7 @@ import (
 func TestAccIosxrInterfaceBundleEtherSubinterface(t *testing.T) {
 	var checks []resource.TestCheckFunc
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_interface_bundle_ether_subinterface.test", "name", "100.100"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_interface_bundle_ether_subinterface.test", "l2transport", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_interface_bundle_ether_subinterface.test", "point_to_point", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_interface_bundle_ether_subinterface.test", "multipoint", "false"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_interface_bundle_ether_subinterface.test", "dampening", "true"))
@@ -526,6 +527,7 @@ func testAccIosxrInterfaceBundleEtherSubinterfaceConfig_minimum() string {
 func testAccIosxrInterfaceBundleEtherSubinterfaceConfig_all() string {
 	config := `resource "iosxr_interface_bundle_ether_subinterface" "test" {` + "\n"
 	config += `	name = "100.100"` + "\n"
+	config += `	l2transport = false` + "\n"
 	config += `	point_to_point = false` + "\n"
 	config += `	multipoint = false` + "\n"
 	config += `	dampening = true` + "\n"


### PR DESCRIPTION
   ## Description
   Add `l2transport` attribute support to `iosxr_interface_bundle_ether_subinterface`
  resource.

   ## Motivation
   Bundle-Ether subinterfaces can be configured as L2 transport interfaces,
   but this attribute was missing from the provider while it was already
   supported for Ethernet subinterfaces.

   ## Testing
   Acceptance tests pass: `make test NAME=InterfaceBundleEtherSubinterface`