### PR TITLE
Add contexts list to iosxr_snmp_server resource

### DIFF
--- a/docs/data-sources/snmp_server.md
+++ b/docs/data-sources/snmp_server.md
@@ -29,6 +29,7 @@ data "iosxr_snmp_server" "example" {
 - `chassis_id` (String) String to uniquely identify this chassis
 - `communities` (Attributes List) The UNENCRYPTED (cleartext) community string (see [below for nested schema](#nestedatt--communities))
 - `contact` (String) Text for mib Object sysContact
+- `contexts` (Attributes List) Context Name (see [below for nested schema](#nestedatt--contexts))
 - `drop_report_acl_ipv4` (String) Type of Access-list
 - `drop_report_acl_ipv6` (String) Type of Access-list
 - `drop_unknown_user` (Boolean) Silently drop unknown v3 user packets
@@ -169,6 +170,14 @@ Read-Only:
 - `sdrowner` (Boolean) SDR Owner permissions for MIB Objects
 - `systemowner` (Boolean) System Owner permissions for MIB objects
 - `view` (String) Restrict this community to a named view
+
+
+<a id="nestedatt--contexts"></a>
+### Nested Schema for `contexts`
+
+Read-Only:
+
+- `name` (String) Context Name
 
 
 <a id="nestedatt--engine_id_remotes"></a>

--- a/docs/resources/snmp_server.md
+++ b/docs/resources/snmp_server.md
@@ -168,6 +168,11 @@ resource "iosxr_snmp_server" "example" {
       ]
     }
   ]
+  contexts = [
+    {
+      name = "CONTEXT1"
+    }
+  ]
   views = [
     {
       view_name = "VIEW1"
@@ -244,6 +249,7 @@ resource "iosxr_snmp_server" "example" {
 - `chassis_id` (String) String to uniquely identify this chassis
 - `communities` (Attributes List) The UNENCRYPTED (cleartext) community string (see [below for nested schema](#nestedatt--communities))
 - `contact` (String) Text for mib Object sysContact
+- `contexts` (Attributes List) Context Name (see [below for nested schema](#nestedatt--contexts))
 - `delete_mode` (String) Configure behavior when deleting/destroying the resource. Either delete the entire object (YANG container) being managed, or only delete the individual resource attributes configured explicitly and leave everything else as-is. Default value is `all`.
   - Choices: `all`, `attributes`
 - `device` (String) A device name from the provider configuration.
@@ -413,6 +419,14 @@ Optional:
 - `sdrowner` (Boolean) SDR Owner permissions for MIB Objects
 - `systemowner` (Boolean) System Owner permissions for MIB objects
 - `view` (String) Restrict this community to a named view
+
+
+<a id="nestedatt--contexts"></a>
+### Nested Schema for `contexts`
+
+Required:
+
+- `name` (String) Context Name
 
 
 <a id="nestedatt--engine_id_remotes"></a>

--- a/examples/resources/iosxr_snmp_server/resource.tf
+++ b/examples/resources/iosxr_snmp_server/resource.tf
@@ -153,6 +153,11 @@ resource "iosxr_snmp_server" "example" {
       ]
     }
   ]
+  contexts = [
+    {
+      name = "CONTEXT1"
+    }
+  ]
   views = [
     {
       view_name = "VIEW1"

--- a/gen/definitions/snmp_server.yaml
+++ b/gen/definitions/snmp_server.yaml
@@ -499,6 +499,14 @@ attributes:
             delete_parent: true
             example: auth
             exclude_test: true
+  - yang_name: context/contexts/context
+    tf_name: contexts
+    type: List
+    attributes:
+      - yang_name: context-name
+        tf_name: name
+        id: true
+        example: CONTEXT1
   - yang_name: views/view
     tf_name: views
     type: List

--- a/internal/provider/data_source_iosxr_snmp_server.go
+++ b/internal/provider/data_source_iosxr_snmp_server.go
@@ -662,6 +662,18 @@ func (d *SNMPServerDataSource) Schema(ctx context.Context, req datasource.Schema
 					},
 				},
 			},
+			"contexts": schema.ListNestedAttribute{
+				MarkdownDescription: "Context Name",
+				Computed:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							MarkdownDescription: "Context Name",
+							Computed:            true,
+						},
+					},
+				},
+			},
 			"views": schema.ListNestedAttribute{
 				MarkdownDescription: "Name of the view",
 				Computed:            true,

--- a/internal/provider/data_source_iosxr_snmp_server_test.go
+++ b/internal/provider/data_source_iosxr_snmp_server_test.go
@@ -147,6 +147,7 @@ func TestAccDataSourceIosxrSNMPServer(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_snmp_server.test", "hosts.0.informs_encrypted_default.0.version_v2c", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_snmp_server.test", "hosts.0.informs_encrypted_aes.0.udp_port", "1100"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_snmp_server.test", "hosts.0.informs_encrypted_aes.0.version_v2c", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_snmp_server.test", "contexts.0.name", "CONTEXT1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_snmp_server.test", "views.0.view_name", "VIEW1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_snmp_server.test", "views.0.mib_view_families.0.name", "1.3.6.1.2.1.1"))
 	checks = append(checks, resource.TestCheckResourceAttr("data.iosxr_snmp_server.test", "views.0.mib_view_families.0.included", "true"))
@@ -374,6 +375,9 @@ func testAccDataSourceIosxrSNMPServerConfig() string {
 	config += `			udp_port = 1100` + "\n"
 	config += `			version_v2c = true` + "\n"
 	config += `		}]` + "\n"
+	config += `	}]` + "\n"
+	config += `	contexts = [{` + "\n"
+	config += `		name = "CONTEXT1"` + "\n"
 	config += `	}]` + "\n"
 	config += `	views = [{` + "\n"
 	config += `		view_name = "VIEW1"` + "\n"

--- a/internal/provider/model_iosxr_snmp_server.go
+++ b/internal/provider/model_iosxr_snmp_server.go
@@ -138,6 +138,7 @@ type SNMPServer struct {
 	TrapsSyslog                                    types.Bool                  `tfsdk:"traps_syslog"`
 	TrapsSystem                                    types.Bool                  `tfsdk:"traps_system"`
 	Hosts                                          []SNMPServerHosts           `tfsdk:"hosts"`
+	Contexts                                       []SNMPServerContexts        `tfsdk:"contexts"`
 	Views                                          []SNMPServerViews           `tfsdk:"views"`
 	TrapSource                                     types.String                `tfsdk:"trap_source"`
 	TrapSourceIpv4                                 types.String                `tfsdk:"trap_source_ipv4"`
@@ -271,6 +272,7 @@ type SNMPServerData struct {
 	TrapsSyslog                                    types.Bool                  `tfsdk:"traps_syslog"`
 	TrapsSystem                                    types.Bool                  `tfsdk:"traps_system"`
 	Hosts                                          []SNMPServerHosts           `tfsdk:"hosts"`
+	Contexts                                       []SNMPServerContexts        `tfsdk:"contexts"`
 	Views                                          []SNMPServerViews           `tfsdk:"views"`
 	TrapSource                                     types.String                `tfsdk:"trap_source"`
 	TrapSourceIpv4                                 types.String                `tfsdk:"trap_source_ipv4"`
@@ -318,6 +320,9 @@ type SNMPServerHosts struct {
 	InformsUnencryptedStrings []SNMPServerHostsInformsUnencryptedStrings `tfsdk:"informs_unencrypted_strings"`
 	InformsEncryptedDefault   []SNMPServerHostsInformsEncryptedDefault   `tfsdk:"informs_encrypted_default"`
 	InformsEncryptedAes       []SNMPServerHostsInformsEncryptedAes       `tfsdk:"informs_encrypted_aes"`
+}
+type SNMPServerContexts struct {
+	Name types.String `tfsdk:"name"`
 }
 type SNMPServerViews struct {
 	ViewName        types.String                     `tfsdk:"view_name"`
@@ -1148,6 +1153,14 @@ func (data SNMPServer) toBody(ctx context.Context) string {
 						body, _ = sjson.Set(body, "hosts.host"+"."+strconv.Itoa(index)+"."+"informs.encrypted.encryption-aeses.encryption-aes"+"."+strconv.Itoa(cindex)+"."+"version.v3.security-level", citem.VersionV3SecurityLevel.ValueString())
 					}
 				}
+			}
+		}
+	}
+	if len(data.Contexts) > 0 {
+		body, _ = sjson.Set(body, "context.contexts.context", []interface{}{})
+		for index, item := range data.Contexts {
+			if !item.Name.IsNull() && !item.Name.IsUnknown() {
+				body, _ = sjson.Set(body, "context.contexts.context"+"."+strconv.Itoa(index)+"."+"context-name", item.Name.ValueString())
 			}
 		}
 	}
@@ -2591,6 +2604,35 @@ func (data *SNMPServer) updateFromBody(ctx context.Context, res []byte) {
 			}
 		}
 	}
+	for i := range data.Contexts {
+		keys := [...]string{"context-name"}
+		keyValues := [...]string{data.Contexts[i].Name.ValueString()}
+
+		var r gjson.Result
+		gjson.GetBytes(res, "context.contexts.context").ForEach(
+			func(_, v gjson.Result) bool {
+				found := false
+				for ik := range keys {
+					if v.Get(keys[ik]).String() == keyValues[ik] {
+						found = true
+						continue
+					}
+					found = false
+					break
+				}
+				if found {
+					r = v
+					return false
+				}
+				return true
+			},
+		)
+		if value := r.Get("context-name"); value.Exists() && !data.Contexts[i].Name.IsNull() {
+			data.Contexts[i].Name = types.StringValue(value.String())
+		} else {
+			data.Contexts[i].Name = types.StringNull()
+		}
+	}
 	for i := range data.Views {
 		keys := [...]string{"view-name"}
 		keyValues := [...]string{data.Views[i].ViewName.ValueString()}
@@ -3759,6 +3801,17 @@ func (data *SNMPServer) fromBody(ctx context.Context, res []byte) {
 			return true
 		})
 	}
+	if value := gjson.GetBytes(res, "context.contexts.context"); value.Exists() {
+		data.Contexts = make([]SNMPServerContexts, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := SNMPServerContexts{}
+			if cValue := v.Get("context-name"); cValue.Exists() {
+				item.Name = types.StringValue(cValue.String())
+			}
+			data.Contexts = append(data.Contexts, item)
+			return true
+		})
+	}
 	if value := gjson.GetBytes(res, "views.view"); value.Exists() {
 		data.Views = make([]SNMPServerViews, 0)
 		value.ForEach(func(k, v gjson.Result) bool {
@@ -4677,6 +4730,17 @@ func (data *SNMPServerData) fromBody(ctx context.Context, res []byte) {
 			return true
 		})
 	}
+	if value := gjson.GetBytes(res, "context.contexts.context"); value.Exists() {
+		data.Contexts = make([]SNMPServerContexts, 0)
+		value.ForEach(func(k, v gjson.Result) bool {
+			item := SNMPServerContexts{}
+			if cValue := v.Get("context-name"); cValue.Exists() {
+				item.Name = types.StringValue(cValue.String())
+			}
+			data.Contexts = append(data.Contexts, item)
+			return true
+		})
+	}
 	if value := gjson.GetBytes(res, "views.view"); value.Exists() {
 		data.Views = make([]SNMPServerViews, 0)
 		value.ForEach(func(k, v gjson.Result) bool {
@@ -5346,6 +5410,36 @@ func (data *SNMPServer) getDeletedItems(ctx context.Context, state SNMPServer) [
 		}
 		if !found {
 			deletedItems = append(deletedItems, fmt.Sprintf("%v/views/view%v", state.getPath(), keyString))
+		}
+	}
+	for i := range state.Contexts {
+		keys := [...]string{"context-name"}
+		stateKeyValues := [...]string{state.Contexts[i].Name.ValueString()}
+		keyString := ""
+		for ki := range keys {
+			keyString += "[" + keys[ki] + "=" + stateKeyValues[ki] + "]"
+		}
+
+		emptyKeys := true
+		if !reflect.ValueOf(state.Contexts[i].Name.ValueString()).IsZero() {
+			emptyKeys = false
+		}
+		if emptyKeys {
+			continue
+		}
+
+		found := false
+		for j := range data.Contexts {
+			found = true
+			if state.Contexts[i].Name.ValueString() != data.Contexts[j].Name.ValueString() {
+				found = false
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			deletedItems = append(deletedItems, fmt.Sprintf("%v/context/contexts/context%v", state.getPath(), keyString))
 		}
 	}
 	for i := range state.Hosts {
@@ -6054,6 +6148,14 @@ func (data *SNMPServer) getEmptyLeafsDelete(ctx context.Context) []string {
 			}
 		}
 	}
+	for i := range data.Contexts {
+		keys := [...]string{"context-name"}
+		keyValues := [...]string{data.Contexts[i].Name.ValueString()}
+		keyString := ""
+		for ki := range keys {
+			keyString += "[" + keys[ki] + "=" + keyValues[ki] + "]"
+		}
+	}
 	for i := range data.Hosts {
 		keys := [...]string{"address"}
 		keyValues := [...]string{data.Hosts[i].Address.ValueString()}
@@ -6532,6 +6634,16 @@ func (data *SNMPServer) getDeletePaths(ctx context.Context) []string {
 			keyString += "[" + keys[ki] + "=" + keyValues[ki] + "]"
 		}
 		deletePaths = append(deletePaths, fmt.Sprintf("%v/views/view%v", data.getPath(), keyString))
+	}
+	for i := range data.Contexts {
+		keys := [...]string{"context-name"}
+		keyValues := [...]string{data.Contexts[i].Name.ValueString()}
+
+		keyString := ""
+		for ki := range keys {
+			keyString += "[" + keys[ki] + "=" + keyValues[ki] + "]"
+		}
+		deletePaths = append(deletePaths, fmt.Sprintf("%v/context/contexts/context%v", data.getPath(), keyString))
 	}
 	for i := range data.Hosts {
 		keys := [...]string{"address"}

--- a/internal/provider/resource_iosxr_snmp_server.go
+++ b/internal/provider/resource_iosxr_snmp_server.go
@@ -777,6 +777,22 @@ func (r *SNMPServerResource) Schema(ctx context.Context, req resource.SchemaRequ
 					},
 				},
 			},
+			"contexts": schema.ListNestedAttribute{
+				MarkdownDescription: helpers.NewAttributeDescription("Context Name").String,
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							MarkdownDescription: helpers.NewAttributeDescription("Context Name").String,
+							Required:            true,
+							Validators: []validator.String{
+								stringvalidator.LengthBetween(1, 32),
+								stringvalidator.RegexMatches(regexp.MustCompile(`[\w\-\.:,_@#%$\+=\| ;]+`), ""),
+							},
+						},
+					},
+				},
+			},
 			"views": schema.ListNestedAttribute{
 				MarkdownDescription: helpers.NewAttributeDescription("Name of the view").String,
 				Optional:            true,

--- a/internal/provider/resource_iosxr_snmp_server_test.go
+++ b/internal/provider/resource_iosxr_snmp_server_test.go
@@ -150,6 +150,7 @@ func TestAccIosxrSNMPServer(t *testing.T) {
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_snmp_server.test", "hosts.0.informs_encrypted_default.0.version_v2c", "true"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_snmp_server.test", "hosts.0.informs_encrypted_aes.0.udp_port", "1100"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_snmp_server.test", "hosts.0.informs_encrypted_aes.0.version_v2c", "true"))
+	checks = append(checks, resource.TestCheckResourceAttr("iosxr_snmp_server.test", "contexts.0.name", "CONTEXT1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_snmp_server.test", "views.0.view_name", "VIEW1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_snmp_server.test", "views.0.mib_view_families.0.name", "1.3.6.1.2.1.1"))
 	checks = append(checks, resource.TestCheckResourceAttr("iosxr_snmp_server.test", "views.0.mib_view_families.0.included", "true"))
@@ -410,6 +411,9 @@ func testAccIosxrSNMPServerConfig_all() string {
 	config += `			udp_port = 1100` + "\n"
 	config += `			version_v2c = true` + "\n"
 	config += `		}]` + "\n"
+	config += `		}]` + "\n"
+	config += `	contexts = [{` + "\n"
+	config += `		name = "CONTEXT1"` + "\n"
 	config += `		}]` + "\n"
 	config += `	views = [{` + "\n"
 	config += `		view_name = "VIEW1"` + "\n"


### PR DESCRIPTION
Adds the `contexts` list attribute to `iosxr_snmp_server`

YANG path: `Cisco-IOS-XR-um-snmp-server-cfg:/snmp-server/context/contexts/context`
E.g. https://github.com/YangModels/yang/blob/main/vendor/cisco/xr/2522/Cisco-IOS-XR-um-snmp-server-cfg.yang#L2576
Verified against YANG models for IOS-XR 24.4.2 and 25.2.2 (both identical in this subtree).

Changes:
- gen/definitions/snmp_server.yaml: add contexts/contexts/context list definition
- Regenerated with `make genall`

Tested:
- `make genall` and `go build`
- Acceptance test passes against IOS-XR 25.4.2

Related: https://github.com/CiscoDevNet/terraform-provider-iosxr/compare/main...shebang42:terraform-provider-iosxr:feature/snmp-contexts
