### PR TITLE
docs(changelog): correct iosxr_gnmi rename note (no compatibility alias)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Fix: Make `auto_cost_reference_bandwidth` optional in `router_isis` resource and data source
 - Fix: preserve resource state when a gNMI read returns an empty response so keys-only resources are no longer perpetually recreated
 - Add NETCONF protocol support (`protocol = "netconf"`) as an alternative to gNMI, with support for NETCONF 1.0/1.1, candidate and running datastore workflows, connection reuse, and automatic capability detection
-- BREAKING CHANGE: Rename resource and data source `iosxr_gnmi` to `iosxr_yang`. Update all HCL references and run `terraform state mv` to migrate existing state. `iosxr_gnmi` remains as a deprecated alias and will be removed in a future version.
+- BREAKING CHANGE: Rename resource and data source `iosxr_gnmi` to `iosxr_yang`. Update all HCL references and run `terraform state mv` to migrate existing state.
 
 ## 0.7.1
 

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -13,7 +13,7 @@ description: |-
 - Fix: Make `auto_cost_reference_bandwidth` optional in `router_isis` resource and data source
 - Fix: preserve resource state when a gNMI read returns an empty response so keys-only resources are no longer perpetually recreated
 - Add NETCONF protocol support (`protocol = "netconf"`) as an alternative to gNMI, with support for NETCONF 1.0/1.1, candidate and running datastore workflows, connection reuse, and automatic capability detection
-- BREAKING CHANGE: Rename resource and data source `iosxr_gnmi` to `iosxr_yang`. Update all HCL references and run `terraform state mv` to migrate existing state. `iosxr_gnmi` remains as a deprecated alias and will be removed in a future version.
+- BREAKING CHANGE: Rename resource and data source `iosxr_gnmi` to `iosxr_yang`. Update all HCL references and run `terraform state mv` to migrate existing state.
 
 ## 0.7.1
 

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -13,7 +13,7 @@ description: |-
 - Fix: Make `auto_cost_reference_bandwidth` optional in `router_isis` resource and data source
 - Fix: preserve resource state when a gNMI read returns an empty response so keys-only resources are no longer perpetually recreated
 - Add NETCONF protocol support (`protocol = "netconf"`) as an alternative to gNMI, with support for NETCONF 1.0/1.1, candidate and running datastore workflows, connection reuse, and automatic capability detection
-- BREAKING CHANGE: Rename resource and data source `iosxr_gnmi` to `iosxr_yang`. Update all HCL references and run `terraform state mv` to migrate existing state. `iosxr_gnmi` remains as a deprecated alias and will be removed in a future version.
+- BREAKING CHANGE: Rename resource and data source `iosxr_gnmi` to `iosxr_yang`. Update all HCL references and run `terraform state mv` to migrate existing state.
 
 ## 0.7.1
 


### PR DESCRIPTION
## Summary

The `0.7.2` changelog states that `iosxr_gnmi` *"remains as a deprecated alias and will be removed in a future version."* That is inaccurate — the rename to `iosxr_yang` was a **hard cut**:

- `GnmiResource` / `NewGnmiResource()` still exist in `resource_iosxr_yang.go`, but are **not registered** in the provider's `Resources()` or `DataSources()` (only `NewYangResource` / `NewYangDataSource` are).
- There is no `DeprecationMessage` and no `GnmiDataSource` at all.
- Therefore Terraform never exposes `iosxr_gnmi`; users cannot keep using it and must rename to `iosxr_yang` + `terraform state mv`.

This PR drops the misleading alias sentence so the entry accurately describes the breaking rename. Documentation-only; no code behavior change.

## Change

- Update the `0.7.2` BREAKING CHANGE entry in `CHANGELOG.md`, `docs/guides/changelog.md`, and `templates/guides/changelog.md.tmpl` to:
  > BREAKING CHANGE: Rename resource and data source `iosxr_gnmi` to `iosxr_yang`. Update all HCL references and run `terraform state mv` to migrate existing state.

Note: the orphaned `GnmiResource` dead code is intentionally left in place for now (can be removed in a separate cleanup PR).

## Test plan

- [x] `make genall` produces no diff (template and generated guide edited consistently).
- [x] Changelog renders correctly.