### PR TITLE
fix(gnmi): keep bare keyed nodes in state and guard empty update bodies

### DIFF
--- a/gen/templates/resource.go
+++ b/gen/templates/resource.go
@@ -403,13 +403,19 @@ func (r *{{camelCase .Name}}Resource) Create(ctx context.Context, req resource.C
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -617,7 +623,6 @@ func (r *{{camelCase .Name}}Resource) Update(ctx context.Context, req resource.U
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -632,6 +637,12 @@ func (r *{{camelCase .Name}}Resource) Update(ctx context.Context, req resource.U
 		for _, i := range emptyLeafsDelete {
 			ops = append(ops, gnmi.Delete(i))
 		}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
+			}
 
 		_, err := device.GnmiClient.Set(ctx, ops)
 			if err != nil {

--- a/internal/provider/helpers/gnmi.go
+++ b/internal/provider/helpers/gnmi.go
@@ -230,7 +230,10 @@ func isGnmiGetResponseEmpty(resp *gnmi.GetRes) bool {
 	// Check if the value is actually empty
 	val := resp.Notifications[0].Update[0].Val
 	if val == nil {
-		return true
+		// An update entry with no value means the keyed node exists but is bare
+		// (e.g. a bare Bundle-Ether), so it's present, not empty. A truly-absent
+		// node returns zero updates (handled above).
+		return false
 	}
 	jsonVal := val.GetJsonIetfVal()
 	jsonStr := strings.TrimSpace(string(jsonVal))

--- a/internal/provider/resource_iosxr_aaa.go
+++ b/internal/provider/resource_iosxr_aaa.go
@@ -2109,13 +2109,19 @@ func (r *AAAResource) Create(ctx context.Context, req resource.CreateRequest, re
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -2322,7 +2328,6 @@ func (r *AAAResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -2336,6 +2341,12 @@ func (r *AAAResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_aaa_accounting.go
+++ b/internal/provider/resource_iosxr_aaa_accounting.go
@@ -543,13 +543,19 @@ func (r *AAAAccountingResource) Create(ctx context.Context, req resource.CreateR
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -756,7 +762,6 @@ func (r *AAAAccountingResource) Update(ctx context.Context, req resource.UpdateR
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -770,6 +775,12 @@ func (r *AAAAccountingResource) Update(ctx context.Context, req resource.UpdateR
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_aaa_authentication.go
+++ b/internal/provider/resource_iosxr_aaa_authentication.go
@@ -235,13 +235,19 @@ func (r *AAAAuthenticationResource) Create(ctx context.Context, req resource.Cre
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -448,7 +454,6 @@ func (r *AAAAuthenticationResource) Update(ctx context.Context, req resource.Upd
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -462,6 +467,12 @@ func (r *AAAAuthenticationResource) Update(ctx context.Context, req resource.Upd
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_aaa_authorization.go
+++ b/internal/provider/resource_iosxr_aaa_authorization.go
@@ -469,13 +469,19 @@ func (r *AAAAuthorizationResource) Create(ctx context.Context, req resource.Crea
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -682,7 +688,6 @@ func (r *AAAAuthorizationResource) Update(ctx context.Context, req resource.Upda
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -696,6 +701,12 @@ func (r *AAAAuthorizationResource) Update(ctx context.Context, req resource.Upda
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_as_path_set.go
+++ b/internal/provider/resource_iosxr_as_path_set.go
@@ -139,13 +139,19 @@ func (r *ASPathSetResource) Create(ctx context.Context, req resource.CreateReque
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *ASPathSetResource) Update(ctx context.Context, req resource.UpdateReque
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *ASPathSetResource) Update(ctx context.Context, req resource.UpdateReque
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_banner.go
+++ b/internal/provider/resource_iosxr_banner.go
@@ -138,13 +138,19 @@ func (r *BannerResource) Create(ctx context.Context, req resource.CreateRequest,
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -351,7 +357,6 @@ func (r *BannerResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -365,6 +370,12 @@ func (r *BannerResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_bfd.go
+++ b/internal/provider/resource_iosxr_bfd.go
@@ -354,13 +354,19 @@ func (r *BFDResource) Create(ctx context.Context, req resource.CreateRequest, re
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -567,7 +573,6 @@ func (r *BFDResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -581,6 +586,12 @@ func (r *BFDResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_bgp_as_format.go
+++ b/internal/provider/resource_iosxr_bgp_as_format.go
@@ -138,13 +138,19 @@ func (r *BGPASFormatResource) Create(ctx context.Context, req resource.CreateReq
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -351,7 +357,6 @@ func (r *BGPASFormatResource) Update(ctx context.Context, req resource.UpdateReq
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -365,6 +370,12 @@ func (r *BGPASFormatResource) Update(ctx context.Context, req resource.UpdateReq
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_bmp_server.go
+++ b/internal/provider/resource_iosxr_bmp_server.go
@@ -288,13 +288,19 @@ func (r *BMPServerResource) Create(ctx context.Context, req resource.CreateReque
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -501,7 +507,6 @@ func (r *BMPServerResource) Update(ctx context.Context, req resource.UpdateReque
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -515,6 +520,12 @@ func (r *BMPServerResource) Update(ctx context.Context, req resource.UpdateReque
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_call_home.go
+++ b/internal/provider/resource_iosxr_call_home.go
@@ -384,13 +384,19 @@ func (r *CallHomeResource) Create(ctx context.Context, req resource.CreateReques
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -597,7 +603,6 @@ func (r *CallHomeResource) Update(ctx context.Context, req resource.UpdateReques
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -611,6 +616,12 @@ func (r *CallHomeResource) Update(ctx context.Context, req resource.UpdateReques
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_cdp.go
+++ b/internal/provider/resource_iosxr_cdp.go
@@ -158,13 +158,19 @@ func (r *CDPResource) Create(ctx context.Context, req resource.CreateRequest, re
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -371,7 +377,6 @@ func (r *CDPResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -385,6 +390,12 @@ func (r *CDPResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_cef.go
+++ b/internal/provider/resource_iosxr_cef.go
@@ -222,13 +222,19 @@ func (r *CEFResource) Create(ctx context.Context, req resource.CreateRequest, re
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -435,7 +441,6 @@ func (r *CEFResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -449,6 +454,12 @@ func (r *CEFResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_cef_load_balancing_8000.go
+++ b/internal/provider/resource_iosxr_cef_load_balancing_8000.go
@@ -318,13 +318,19 @@ func (r *CEFLoadBalancing8000Resource) Create(ctx context.Context, req resource.
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -531,7 +537,6 @@ func (r *CEFLoadBalancing8000Resource) Update(ctx context.Context, req resource.
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -545,6 +550,12 @@ func (r *CEFLoadBalancing8000Resource) Update(ctx context.Context, req resource.
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_cef_pbts_forward_class.go
+++ b/internal/provider/resource_iosxr_cef_pbts_forward_class.go
@@ -142,13 +142,19 @@ func (r *CEFPBTSForwardClassResource) Create(ctx context.Context, req resource.C
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -355,7 +361,6 @@ func (r *CEFPBTSForwardClassResource) Update(ctx context.Context, req resource.U
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -369,6 +374,12 @@ func (r *CEFPBTSForwardClassResource) Update(ctx context.Context, req resource.U
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_class_map_qos.go
+++ b/internal/provider/resource_iosxr_class_map_qos.go
@@ -410,13 +410,19 @@ func (r *ClassMapQoSResource) Create(ctx context.Context, req resource.CreateReq
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -623,7 +629,6 @@ func (r *ClassMapQoSResource) Update(ctx context.Context, req resource.UpdateReq
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -637,6 +642,12 @@ func (r *ClassMapQoSResource) Update(ctx context.Context, req resource.UpdateReq
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_class_map_traffic.go
+++ b/internal/provider/resource_iosxr_class_map_traffic.go
@@ -400,13 +400,19 @@ func (r *ClassMapTrafficResource) Create(ctx context.Context, req resource.Creat
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -613,7 +619,6 @@ func (r *ClassMapTrafficResource) Update(ctx context.Context, req resource.Updat
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -627,6 +632,12 @@ func (r *ClassMapTrafficResource) Update(ctx context.Context, req resource.Updat
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_cli_alias.go
+++ b/internal/provider/resource_iosxr_cli_alias.go
@@ -197,13 +197,19 @@ func (r *CLIAliasResource) Create(ctx context.Context, req resource.CreateReques
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -410,7 +416,6 @@ func (r *CLIAliasResource) Update(ctx context.Context, req resource.UpdateReques
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -424,6 +429,12 @@ func (r *CLIAliasResource) Update(ctx context.Context, req resource.UpdateReques
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_community_set.go
+++ b/internal/provider/resource_iosxr_community_set.go
@@ -139,13 +139,19 @@ func (r *CommunitySetResource) Create(ctx context.Context, req resource.CreateRe
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *CommunitySetResource) Update(ctx context.Context, req resource.UpdateRe
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *CommunitySetResource) Update(ctx context.Context, req resource.UpdateRe
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_control_plane.go
+++ b/internal/provider/resource_iosxr_control_plane.go
@@ -2699,13 +2699,19 @@ func (r *ControlPlaneResource) Create(ctx context.Context, req resource.CreateRe
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -2912,7 +2918,6 @@ func (r *ControlPlaneResource) Update(ctx context.Context, req resource.UpdateRe
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -2926,6 +2931,12 @@ func (r *ControlPlaneResource) Update(ctx context.Context, req resource.UpdateRe
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_controller_optics.go
+++ b/internal/provider/resource_iosxr_controller_optics.go
@@ -199,13 +199,19 @@ func (r *ControllerOpticsResource) Create(ctx context.Context, req resource.Crea
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -412,7 +418,6 @@ func (r *ControllerOpticsResource) Update(ctx context.Context, req resource.Upda
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -426,6 +431,12 @@ func (r *ControllerOpticsResource) Update(ctx context.Context, req resource.Upda
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_crypto.go
+++ b/internal/provider/resource_iosxr_crypto.go
@@ -619,13 +619,19 @@ func (r *CryptoResource) Create(ctx context.Context, req resource.CreateRequest,
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -832,7 +838,6 @@ func (r *CryptoResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -846,6 +851,12 @@ func (r *CryptoResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_domain.go
+++ b/internal/provider/resource_iosxr_domain.go
@@ -246,13 +246,19 @@ func (r *DomainResource) Create(ctx context.Context, req resource.CreateRequest,
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -459,7 +465,6 @@ func (r *DomainResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -473,6 +478,12 @@ func (r *DomainResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_domain_vrf.go
+++ b/internal/provider/resource_iosxr_domain_vrf.go
@@ -253,13 +253,19 @@ func (r *DomainVRFResource) Create(ctx context.Context, req resource.CreateReque
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -466,7 +472,6 @@ func (r *DomainVRFResource) Update(ctx context.Context, req resource.UpdateReque
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -480,6 +485,12 @@ func (r *DomainVRFResource) Update(ctx context.Context, req resource.UpdateReque
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_error_disable_recovery.go
+++ b/internal/provider/resource_iosxr_error_disable_recovery.go
@@ -272,13 +272,19 @@ func (r *ErrorDisableRecoveryResource) Create(ctx context.Context, req resource.
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -485,7 +491,6 @@ func (r *ErrorDisableRecoveryResource) Update(ctx context.Context, req resource.
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -499,6 +504,12 @@ func (r *ErrorDisableRecoveryResource) Update(ctx context.Context, req resource.
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_esi_set.go
+++ b/internal/provider/resource_iosxr_esi_set.go
@@ -139,13 +139,19 @@ func (r *ESISetResource) Create(ctx context.Context, req resource.CreateRequest,
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *ESISetResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *ESISetResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_etag_set.go
+++ b/internal/provider/resource_iosxr_etag_set.go
@@ -139,13 +139,19 @@ func (r *EtagSetResource) Create(ctx context.Context, req resource.CreateRequest
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *EtagSetResource) Update(ctx context.Context, req resource.UpdateRequest
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *EtagSetResource) Update(ctx context.Context, req resource.UpdateRequest
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ethernet_cfm.go
+++ b/internal/provider/resource_iosxr_ethernet_cfm.go
@@ -532,13 +532,19 @@ func (r *EthernetCFMResource) Create(ctx context.Context, req resource.CreateReq
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -745,7 +751,6 @@ func (r *EthernetCFMResource) Update(ctx context.Context, req resource.UpdateReq
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -759,6 +764,12 @@ func (r *EthernetCFMResource) Update(ctx context.Context, req resource.UpdateReq
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ethernet_sla.go
+++ b/internal/provider/resource_iosxr_ethernet_sla.go
@@ -445,13 +445,19 @@ func (r *EthernetSLAResource) Create(ctx context.Context, req resource.CreateReq
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -658,7 +664,6 @@ func (r *EthernetSLAResource) Update(ctx context.Context, req resource.UpdateReq
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -672,6 +677,12 @@ func (r *EthernetSLAResource) Update(ctx context.Context, req resource.UpdateReq
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_evpn.go
+++ b/internal/provider/resource_iosxr_evpn.go
@@ -605,13 +605,19 @@ func (r *EVPNResource) Create(ctx context.Context, req resource.CreateRequest, r
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -818,7 +824,6 @@ func (r *EVPNResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -832,6 +837,12 @@ func (r *EVPNResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_evpn_evi.go
+++ b/internal/provider/resource_iosxr_evpn_evi.go
@@ -513,13 +513,19 @@ func (r *EVPNEVIResource) Create(ctx context.Context, req resource.CreateRequest
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -726,7 +732,6 @@ func (r *EVPNEVIResource) Update(ctx context.Context, req resource.UpdateRequest
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -740,6 +745,12 @@ func (r *EVPNEVIResource) Update(ctx context.Context, req resource.UpdateRequest
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_evpn_interface.go
+++ b/internal/provider/resource_iosxr_evpn_interface.go
@@ -265,13 +265,19 @@ func (r *EVPNInterfaceResource) Create(ctx context.Context, req resource.CreateR
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -478,7 +484,6 @@ func (r *EVPNInterfaceResource) Update(ctx context.Context, req resource.UpdateR
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -492,6 +497,12 @@ func (r *EVPNInterfaceResource) Update(ctx context.Context, req resource.UpdateR
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_evpn_route_sync_evi.go
+++ b/internal/provider/resource_iosxr_evpn_route_sync_evi.go
@@ -400,13 +400,19 @@ func (r *EVPNRouteSyncEVIResource) Create(ctx context.Context, req resource.Crea
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -613,7 +619,6 @@ func (r *EVPNRouteSyncEVIResource) Update(ctx context.Context, req resource.Upda
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -627,6 +632,12 @@ func (r *EVPNRouteSyncEVIResource) Update(ctx context.Context, req resource.Upda
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_evpn_route_sync_stitching_evi.go
+++ b/internal/provider/resource_iosxr_evpn_route_sync_stitching_evi.go
@@ -400,13 +400,19 @@ func (r *EVPNRouteSyncStitchingEVIResource) Create(ctx context.Context, req reso
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -613,7 +619,6 @@ func (r *EVPNRouteSyncStitchingEVIResource) Update(ctx context.Context, req reso
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -627,6 +632,12 @@ func (r *EVPNRouteSyncStitchingEVIResource) Update(ctx context.Context, req reso
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_evpn_segment_routing_srv6_evi.go
+++ b/internal/provider/resource_iosxr_evpn_segment_routing_srv6_evi.go
@@ -506,13 +506,19 @@ func (r *EVPNSegmentRoutingSRv6EVIResource) Create(ctx context.Context, req reso
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -719,7 +725,6 @@ func (r *EVPNSegmentRoutingSRv6EVIResource) Update(ctx context.Context, req reso
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -733,6 +738,12 @@ func (r *EVPNSegmentRoutingSRv6EVIResource) Update(ctx context.Context, req reso
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_evpn_segment_routing_srv6_stitching_evi.go
+++ b/internal/provider/resource_iosxr_evpn_segment_routing_srv6_stitching_evi.go
@@ -474,13 +474,19 @@ func (r *EVPNSegmentRoutingSRv6StitchingEVIResource) Create(ctx context.Context,
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -687,7 +693,6 @@ func (r *EVPNSegmentRoutingSRv6StitchingEVIResource) Update(ctx context.Context,
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -701,6 +706,12 @@ func (r *EVPNSegmentRoutingSRv6StitchingEVIResource) Update(ctx context.Context,
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_evpn_stitching_evi.go
+++ b/internal/provider/resource_iosxr_evpn_stitching_evi.go
@@ -513,13 +513,19 @@ func (r *EVPNStitchingEVIResource) Create(ctx context.Context, req resource.Crea
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -726,7 +732,6 @@ func (r *EVPNStitchingEVIResource) Update(ctx context.Context, req resource.Upda
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -740,6 +745,12 @@ func (r *EVPNStitchingEVIResource) Update(ctx context.Context, req resource.Upda
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_evpn_stitching_vni.go
+++ b/internal/provider/resource_iosxr_evpn_stitching_vni.go
@@ -420,13 +420,19 @@ func (r *EVPNStitchingVNIResource) Create(ctx context.Context, req resource.Crea
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -633,7 +639,6 @@ func (r *EVPNStitchingVNIResource) Update(ctx context.Context, req resource.Upda
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -647,6 +652,12 @@ func (r *EVPNStitchingVNIResource) Update(ctx context.Context, req resource.Upda
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_evpn_vni.go
+++ b/internal/provider/resource_iosxr_evpn_vni.go
@@ -420,13 +420,19 @@ func (r *EVPNVNIResource) Create(ctx context.Context, req resource.CreateRequest
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -633,7 +639,6 @@ func (r *EVPNVNIResource) Update(ctx context.Context, req resource.UpdateRequest
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -647,6 +652,12 @@ func (r *EVPNVNIResource) Update(ctx context.Context, req resource.UpdateRequest
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_extcommunity_bandwidth_set.go
+++ b/internal/provider/resource_iosxr_extcommunity_bandwidth_set.go
@@ -139,13 +139,19 @@ func (r *ExtcommunityBandwidthSetResource) Create(ctx context.Context, req resou
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *ExtcommunityBandwidthSetResource) Update(ctx context.Context, req resou
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *ExtcommunityBandwidthSetResource) Update(ctx context.Context, req resou
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_extcommunity_cost_set.go
+++ b/internal/provider/resource_iosxr_extcommunity_cost_set.go
@@ -139,13 +139,19 @@ func (r *ExtcommunityCostSetResource) Create(ctx context.Context, req resource.C
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *ExtcommunityCostSetResource) Update(ctx context.Context, req resource.U
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *ExtcommunityCostSetResource) Update(ctx context.Context, req resource.U
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_extcommunity_evpn_link_bandwidth_set.go
+++ b/internal/provider/resource_iosxr_extcommunity_evpn_link_bandwidth_set.go
@@ -139,13 +139,19 @@ func (r *ExtcommunityEVPNLinkBandwidthSetResource) Create(ctx context.Context, r
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *ExtcommunityEVPNLinkBandwidthSetResource) Update(ctx context.Context, r
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *ExtcommunityEVPNLinkBandwidthSetResource) Update(ctx context.Context, r
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_extcommunity_opaque_set.go
+++ b/internal/provider/resource_iosxr_extcommunity_opaque_set.go
@@ -139,13 +139,19 @@ func (r *ExtcommunityOpaqueSetResource) Create(ctx context.Context, req resource
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *ExtcommunityOpaqueSetResource) Update(ctx context.Context, req resource
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *ExtcommunityOpaqueSetResource) Update(ctx context.Context, req resource
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_extcommunity_rt_set.go
+++ b/internal/provider/resource_iosxr_extcommunity_rt_set.go
@@ -139,13 +139,19 @@ func (r *ExtcommunityRTSetResource) Create(ctx context.Context, req resource.Cre
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *ExtcommunityRTSetResource) Update(ctx context.Context, req resource.Upd
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *ExtcommunityRTSetResource) Update(ctx context.Context, req resource.Upd
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_extcommunity_seg_nh_set.go
+++ b/internal/provider/resource_iosxr_extcommunity_seg_nh_set.go
@@ -139,13 +139,19 @@ func (r *ExtcommunitySegNHSetResource) Create(ctx context.Context, req resource.
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *ExtcommunitySegNHSetResource) Update(ctx context.Context, req resource.
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *ExtcommunitySegNHSetResource) Update(ctx context.Context, req resource.
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_extcommunity_soo_set.go
+++ b/internal/provider/resource_iosxr_extcommunity_soo_set.go
@@ -139,13 +139,19 @@ func (r *ExtcommunitySOOSetResource) Create(ctx context.Context, req resource.Cr
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *ExtcommunitySOOSetResource) Update(ctx context.Context, req resource.Up
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *ExtcommunitySOOSetResource) Update(ctx context.Context, req resource.Up
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_flow_exporter_map.go
+++ b/internal/provider/resource_iosxr_flow_exporter_map.go
@@ -284,13 +284,19 @@ func (r *FlowExporterMapResource) Create(ctx context.Context, req resource.Creat
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -497,7 +503,6 @@ func (r *FlowExporterMapResource) Update(ctx context.Context, req resource.Updat
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -511,6 +516,12 @@ func (r *FlowExporterMapResource) Update(ctx context.Context, req resource.Updat
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_flow_monitor_map.go
+++ b/internal/provider/resource_iosxr_flow_monitor_map.go
@@ -414,13 +414,19 @@ func (r *FlowMonitorMapResource) Create(ctx context.Context, req resource.Create
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -627,7 +633,6 @@ func (r *FlowMonitorMapResource) Update(ctx context.Context, req resource.Update
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -641,6 +646,12 @@ func (r *FlowMonitorMapResource) Update(ctx context.Context, req resource.Update
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_flow_sampler_map.go
+++ b/internal/provider/resource_iosxr_flow_sampler_map.go
@@ -151,13 +151,19 @@ func (r *FlowSamplerMapResource) Create(ctx context.Context, req resource.Create
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -364,7 +370,6 @@ func (r *FlowSamplerMapResource) Update(ctx context.Context, req resource.Update
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -378,6 +383,12 @@ func (r *FlowSamplerMapResource) Update(ctx context.Context, req resource.Update
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_fpd.go
+++ b/internal/provider/resource_iosxr_fpd.go
@@ -147,13 +147,19 @@ func (r *FPDResource) Create(ctx context.Context, req resource.CreateRequest, re
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -360,7 +366,6 @@ func (r *FPDResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -374,6 +379,12 @@ func (r *FPDResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_frequency_synchronization.go
+++ b/internal/provider/resource_iosxr_frequency_synchronization.go
@@ -175,13 +175,19 @@ func (r *FrequencySynchronizationResource) Create(ctx context.Context, req resou
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -388,7 +394,6 @@ func (r *FrequencySynchronizationResource) Update(ctx context.Context, req resou
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -402,6 +407,12 @@ func (r *FrequencySynchronizationResource) Update(ctx context.Context, req resou
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ftp.go
+++ b/internal/provider/resource_iosxr_ftp.go
@@ -183,13 +183,19 @@ func (r *FTPResource) Create(ctx context.Context, req resource.CreateRequest, re
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -396,7 +402,6 @@ func (r *FTPResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -410,6 +415,12 @@ func (r *FTPResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_generic_interface_list.go
+++ b/internal/provider/resource_iosxr_generic_interface_list.go
@@ -158,13 +158,19 @@ func (r *GenericInterfaceListResource) Create(ctx context.Context, req resource.
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -371,7 +377,6 @@ func (r *GenericInterfaceListResource) Update(ctx context.Context, req resource.
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -385,6 +390,12 @@ func (r *GenericInterfaceListResource) Update(ctx context.Context, req resource.
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_hostname.go
+++ b/internal/provider/resource_iosxr_hostname.go
@@ -134,13 +134,19 @@ func (r *HostnameResource) Create(ctx context.Context, req resource.CreateReques
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -347,7 +353,6 @@ func (r *HostnameResource) Update(ctx context.Context, req resource.UpdateReques
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -361,6 +366,12 @@ func (r *HostnameResource) Update(ctx context.Context, req resource.UpdateReques
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_hw_module_profile.go
+++ b/internal/provider/resource_iosxr_hw_module_profile.go
@@ -532,13 +532,19 @@ func (r *HWModuleProfileResource) Create(ctx context.Context, req resource.Creat
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -745,7 +751,6 @@ func (r *HWModuleProfileResource) Update(ctx context.Context, req resource.Updat
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -759,6 +764,12 @@ func (r *HWModuleProfileResource) Update(ctx context.Context, req resource.Updat
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_hw_module_profile_8000.go
+++ b/internal/provider/resource_iosxr_hw_module_profile_8000.go
@@ -802,13 +802,19 @@ func (r *HWModuleProfile8000Resource) Create(ctx context.Context, req resource.C
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1015,7 +1021,6 @@ func (r *HWModuleProfile8000Resource) Update(ctx context.Context, req resource.U
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1029,6 +1034,12 @@ func (r *HWModuleProfile8000Resource) Update(ctx context.Context, req resource.U
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_hw_module_shutdown.go
+++ b/internal/provider/resource_iosxr_hw_module_shutdown.go
@@ -142,13 +142,19 @@ func (r *HWModuleShutdownResource) Create(ctx context.Context, req resource.Crea
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -355,7 +361,6 @@ func (r *HWModuleShutdownResource) Update(ctx context.Context, req resource.Upda
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -369,6 +374,12 @@ func (r *HWModuleShutdownResource) Update(ctx context.Context, req resource.Upda
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_icmp.go
+++ b/internal/provider/resource_iosxr_icmp.go
@@ -170,13 +170,19 @@ func (r *ICMPResource) Create(ctx context.Context, req resource.CreateRequest, r
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -383,7 +389,6 @@ func (r *ICMPResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -397,6 +402,12 @@ func (r *ICMPResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_interface_bundle_ether.go
+++ b/internal/provider/resource_iosxr_interface_bundle_ether.go
@@ -1920,13 +1920,19 @@ func (r *InterfaceBundleEtherResource) Create(ctx context.Context, req resource.
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -2133,7 +2139,6 @@ func (r *InterfaceBundleEtherResource) Update(ctx context.Context, req resource.
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -2147,6 +2152,12 @@ func (r *InterfaceBundleEtherResource) Update(ctx context.Context, req resource.
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_interface_bundle_ether_subinterface.go
+++ b/internal/provider/resource_iosxr_interface_bundle_ether_subinterface.go
@@ -1780,13 +1780,19 @@ func (r *InterfaceBundleEtherSubinterfaceResource) Create(ctx context.Context, r
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1993,7 +1999,6 @@ func (r *InterfaceBundleEtherSubinterfaceResource) Update(ctx context.Context, r
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -2007,6 +2012,12 @@ func (r *InterfaceBundleEtherSubinterfaceResource) Update(ctx context.Context, r
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_interface_bvi.go
+++ b/internal/provider/resource_iosxr_interface_bvi.go
@@ -1444,13 +1444,19 @@ func (r *InterfaceBVIResource) Create(ctx context.Context, req resource.CreateRe
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1657,7 +1663,6 @@ func (r *InterfaceBVIResource) Update(ctx context.Context, req resource.UpdateRe
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1671,6 +1676,12 @@ func (r *InterfaceBVIResource) Update(ctx context.Context, req resource.UpdateRe
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_interface_ethernet.go
+++ b/internal/provider/resource_iosxr_interface_ethernet.go
@@ -2090,13 +2090,19 @@ func (r *InterfaceEthernetResource) Create(ctx context.Context, req resource.Cre
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -2303,7 +2309,6 @@ func (r *InterfaceEthernetResource) Update(ctx context.Context, req resource.Upd
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -2317,6 +2322,12 @@ func (r *InterfaceEthernetResource) Update(ctx context.Context, req resource.Upd
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_interface_ethernet_subinterface.go
+++ b/internal/provider/resource_iosxr_interface_ethernet_subinterface.go
@@ -1830,13 +1830,19 @@ func (r *InterfaceEthernetSubinterfaceResource) Create(ctx context.Context, req 
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -2043,7 +2049,6 @@ func (r *InterfaceEthernetSubinterfaceResource) Update(ctx context.Context, req 
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -2057,6 +2062,12 @@ func (r *InterfaceEthernetSubinterfaceResource) Update(ctx context.Context, req 
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_interface_loopback.go
+++ b/internal/provider/resource_iosxr_interface_loopback.go
@@ -501,13 +501,19 @@ func (r *InterfaceLoopbackResource) Create(ctx context.Context, req resource.Cre
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -714,7 +720,6 @@ func (r *InterfaceLoopbackResource) Update(ctx context.Context, req resource.Upd
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -728,6 +733,12 @@ func (r *InterfaceLoopbackResource) Update(ctx context.Context, req resource.Upd
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_interface_tunnel_ip.go
+++ b/internal/provider/resource_iosxr_interface_tunnel_ip.go
@@ -461,13 +461,19 @@ func (r *InterfaceTunnelIPResource) Create(ctx context.Context, req resource.Cre
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -674,7 +680,6 @@ func (r *InterfaceTunnelIPResource) Update(ctx context.Context, req resource.Upd
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -688,6 +693,12 @@ func (r *InterfaceTunnelIPResource) Update(ctx context.Context, req resource.Upd
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_interface_tunnel_te.go
+++ b/internal/provider/resource_iosxr_interface_tunnel_te.go
@@ -793,13 +793,19 @@ func (r *InterfaceTunnelTEResource) Create(ctx context.Context, req resource.Cre
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1006,7 +1012,6 @@ func (r *InterfaceTunnelTEResource) Update(ctx context.Context, req resource.Upd
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1020,6 +1025,12 @@ func (r *InterfaceTunnelTEResource) Update(ctx context.Context, req resource.Upd
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ipsla.go
+++ b/internal/provider/resource_iosxr_ipsla.go
@@ -1139,13 +1139,19 @@ func (r *IPSLAResource) Create(ctx context.Context, req resource.CreateRequest, 
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1352,7 +1358,6 @@ func (r *IPSLAResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1366,6 +1371,12 @@ func (r *IPSLAResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ipsla_responder.go
+++ b/internal/provider/resource_iosxr_ipsla_responder.go
@@ -283,13 +283,19 @@ func (r *IPSLAResponderResource) Create(ctx context.Context, req resource.Create
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -496,7 +502,6 @@ func (r *IPSLAResponderResource) Update(ctx context.Context, req resource.Update
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -510,6 +515,12 @@ func (r *IPSLAResponderResource) Update(ctx context.Context, req resource.Update
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ipv4_access_list.go
+++ b/internal/provider/resource_iosxr_ipv4_access_list.go
@@ -1152,13 +1152,19 @@ func (r *IPv4AccessListResource) Create(ctx context.Context, req resource.Create
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1365,7 +1371,6 @@ func (r *IPv4AccessListResource) Update(ctx context.Context, req resource.Update
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1379,6 +1384,12 @@ func (r *IPv4AccessListResource) Update(ctx context.Context, req resource.Update
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ipv4_access_list_options.go
+++ b/internal/provider/resource_iosxr_ipv4_access_list_options.go
@@ -154,13 +154,19 @@ func (r *IPv4AccessListOptionsResource) Create(ctx context.Context, req resource
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -367,7 +373,6 @@ func (r *IPv4AccessListOptionsResource) Update(ctx context.Context, req resource
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -381,6 +386,12 @@ func (r *IPv4AccessListOptionsResource) Update(ctx context.Context, req resource
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ipv4_prefix_list.go
+++ b/internal/provider/resource_iosxr_ipv4_prefix_list.go
@@ -203,13 +203,19 @@ func (r *IPv4PrefixListResource) Create(ctx context.Context, req resource.Create
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -416,7 +422,6 @@ func (r *IPv4PrefixListResource) Update(ctx context.Context, req resource.Update
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -430,6 +435,12 @@ func (r *IPv4PrefixListResource) Update(ctx context.Context, req resource.Update
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ipv6.go
+++ b/internal/provider/resource_iosxr_ipv6.go
@@ -194,13 +194,19 @@ func (r *IPv6Resource) Create(ctx context.Context, req resource.CreateRequest, r
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -407,7 +413,6 @@ func (r *IPv6Resource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -421,6 +426,12 @@ func (r *IPv6Resource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ipv6_access_list.go
+++ b/internal/provider/resource_iosxr_ipv6_access_list.go
@@ -1000,13 +1000,19 @@ func (r *IPv6AccessListResource) Create(ctx context.Context, req resource.Create
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1213,7 +1219,6 @@ func (r *IPv6AccessListResource) Update(ctx context.Context, req resource.Update
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1227,6 +1232,12 @@ func (r *IPv6AccessListResource) Update(ctx context.Context, req resource.Update
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ipv6_access_list_options.go
+++ b/internal/provider/resource_iosxr_ipv6_access_list_options.go
@@ -154,13 +154,19 @@ func (r *IPv6AccessListOptionsResource) Create(ctx context.Context, req resource
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -367,7 +373,6 @@ func (r *IPv6AccessListOptionsResource) Update(ctx context.Context, req resource
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -381,6 +386,12 @@ func (r *IPv6AccessListOptionsResource) Update(ctx context.Context, req resource
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ipv6_prefix_list.go
+++ b/internal/provider/resource_iosxr_ipv6_prefix_list.go
@@ -214,13 +214,19 @@ func (r *IPv6PrefixListResource) Create(ctx context.Context, req resource.Create
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -427,7 +433,6 @@ func (r *IPv6PrefixListResource) Update(ctx context.Context, req resource.Update
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -441,6 +446,12 @@ func (r *IPv6PrefixListResource) Update(ctx context.Context, req resource.Update
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_key_chain.go
+++ b/internal/provider/resource_iosxr_key_chain.go
@@ -520,13 +520,19 @@ func (r *KeyChainResource) Create(ctx context.Context, req resource.CreateReques
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -733,7 +739,6 @@ func (r *KeyChainResource) Update(ctx context.Context, req resource.UpdateReques
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -747,6 +752,12 @@ func (r *KeyChainResource) Update(ctx context.Context, req resource.UpdateReques
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_l2vpn.go
+++ b/internal/provider/resource_iosxr_l2vpn.go
@@ -431,13 +431,19 @@ func (r *L2VPNResource) Create(ctx context.Context, req resource.CreateRequest, 
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -644,7 +650,6 @@ func (r *L2VPNResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -658,6 +663,12 @@ func (r *L2VPNResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_l2vpn_bridge_group_bridge_domain.go
+++ b/internal/provider/resource_iosxr_l2vpn_bridge_group_bridge_domain.go
@@ -792,13 +792,19 @@ func (r *L2VPNBridgeGroupBridgeDomainResource) Create(ctx context.Context, req r
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1005,7 +1011,6 @@ func (r *L2VPNBridgeGroupBridgeDomainResource) Update(ctx context.Context, req r
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1019,6 +1024,12 @@ func (r *L2VPNBridgeGroupBridgeDomainResource) Update(ctx context.Context, req r
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_l2vpn_bridge_group_bridge_domain_access_vfi.go
+++ b/internal/provider/resource_iosxr_l2vpn_bridge_group_bridge_domain_access_vfi.go
@@ -216,13 +216,19 @@ func (r *L2VPNBridgeGroupBridgeDomainAccessVFIResource) Create(ctx context.Conte
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -429,7 +435,6 @@ func (r *L2VPNBridgeGroupBridgeDomainAccessVFIResource) Update(ctx context.Conte
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -443,6 +448,12 @@ func (r *L2VPNBridgeGroupBridgeDomainAccessVFIResource) Update(ctx context.Conte
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_l2vpn_bridge_group_bridge_domain_neighbor.go
+++ b/internal/provider/resource_iosxr_l2vpn_bridge_group_bridge_domain_neighbor.go
@@ -429,13 +429,19 @@ func (r *L2VPNBridgeGroupBridgeDomainNeighborResource) Create(ctx context.Contex
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -642,7 +648,6 @@ func (r *L2VPNBridgeGroupBridgeDomainNeighborResource) Update(ctx context.Contex
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -656,6 +661,12 @@ func (r *L2VPNBridgeGroupBridgeDomainNeighborResource) Update(ctx context.Contex
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_l2vpn_bridge_group_bridge_domain_vfi.go
+++ b/internal/provider/resource_iosxr_l2vpn_bridge_group_bridge_domain_vfi.go
@@ -638,13 +638,19 @@ func (r *L2VPNBridgeGroupBridgeDomainVFIResource) Create(ctx context.Context, re
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -851,7 +857,6 @@ func (r *L2VPNBridgeGroupBridgeDomainVFIResource) Update(ctx context.Context, re
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -865,6 +870,12 @@ func (r *L2VPNBridgeGroupBridgeDomainVFIResource) Update(ctx context.Context, re
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_l2vpn_pw_class.go
+++ b/internal/provider/resource_iosxr_l2vpn_pw_class.go
@@ -327,13 +327,19 @@ func (r *L2VPNPWClassResource) Create(ctx context.Context, req resource.CreateRe
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -540,7 +546,6 @@ func (r *L2VPNPWClassResource) Update(ctx context.Context, req resource.UpdateRe
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -554,6 +559,12 @@ func (r *L2VPNPWClassResource) Update(ctx context.Context, req resource.UpdateRe
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_l2vpn_xconnect_group.go
+++ b/internal/provider/resource_iosxr_l2vpn_xconnect_group.go
@@ -928,13 +928,19 @@ func (r *L2VPNXconnectGroupResource) Create(ctx context.Context, req resource.Cr
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1141,7 +1147,6 @@ func (r *L2VPNXconnectGroupResource) Update(ctx context.Context, req resource.Up
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1155,6 +1160,12 @@ func (r *L2VPNXconnectGroupResource) Update(ctx context.Context, req resource.Up
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_lacp.go
+++ b/internal/provider/resource_iosxr_lacp.go
@@ -147,13 +147,19 @@ func (r *LACPResource) Create(ctx context.Context, req resource.CreateRequest, r
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -360,7 +366,6 @@ func (r *LACPResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -374,6 +379,12 @@ func (r *LACPResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_large_community_set.go
+++ b/internal/provider/resource_iosxr_large_community_set.go
@@ -139,13 +139,19 @@ func (r *LargeCommunitySetResource) Create(ctx context.Context, req resource.Cre
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *LargeCommunitySetResource) Update(ctx context.Context, req resource.Upd
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *LargeCommunitySetResource) Update(ctx context.Context, req resource.Upd
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_line_console.go
+++ b/internal/provider/resource_iosxr_line_console.go
@@ -340,13 +340,19 @@ func (r *LineConsoleResource) Create(ctx context.Context, req resource.CreateReq
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -553,7 +559,6 @@ func (r *LineConsoleResource) Update(ctx context.Context, req resource.UpdateReq
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -567,6 +572,12 @@ func (r *LineConsoleResource) Update(ctx context.Context, req resource.UpdateReq
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_line_default.go
+++ b/internal/provider/resource_iosxr_line_default.go
@@ -347,13 +347,19 @@ func (r *LineDefaultResource) Create(ctx context.Context, req resource.CreateReq
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -560,7 +566,6 @@ func (r *LineDefaultResource) Update(ctx context.Context, req resource.UpdateReq
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -574,6 +579,12 @@ func (r *LineDefaultResource) Update(ctx context.Context, req resource.UpdateReq
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_line_template.go
+++ b/internal/provider/resource_iosxr_line_template.go
@@ -358,13 +358,19 @@ func (r *LineTemplateResource) Create(ctx context.Context, req resource.CreateRe
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -571,7 +577,6 @@ func (r *LineTemplateResource) Update(ctx context.Context, req resource.UpdateRe
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -585,6 +590,12 @@ func (r *LineTemplateResource) Update(ctx context.Context, req resource.UpdateRe
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_linux_networking.go
+++ b/internal/provider/resource_iosxr_linux_networking.go
@@ -301,13 +301,19 @@ func (r *LinuxNetworkingResource) Create(ctx context.Context, req resource.Creat
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -514,7 +520,6 @@ func (r *LinuxNetworkingResource) Update(ctx context.Context, req resource.Updat
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -528,6 +533,12 @@ func (r *LinuxNetworkingResource) Update(ctx context.Context, req resource.Updat
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_lldp.go
+++ b/internal/provider/resource_iosxr_lldp.go
@@ -249,13 +249,19 @@ func (r *LLDPResource) Create(ctx context.Context, req resource.CreateRequest, r
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -462,7 +468,6 @@ func (r *LLDPResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -476,6 +481,12 @@ func (r *LLDPResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_logging.go
+++ b/internal/provider/resource_iosxr_logging.go
@@ -637,13 +637,19 @@ func (r *LoggingResource) Create(ctx context.Context, req resource.CreateRequest
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -850,7 +856,6 @@ func (r *LoggingResource) Update(ctx context.Context, req resource.UpdateRequest
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -864,6 +869,12 @@ func (r *LoggingResource) Update(ctx context.Context, req resource.UpdateRequest
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_logging_vrf.go
+++ b/internal/provider/resource_iosxr_logging_vrf.go
@@ -295,13 +295,19 @@ func (r *LoggingVRFResource) Create(ctx context.Context, req resource.CreateRequ
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -508,7 +514,6 @@ func (r *LoggingVRFResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -522,6 +527,12 @@ func (r *LoggingVRFResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_lpts_punt_police.go
+++ b/internal/provider/resource_iosxr_lpts_punt_police.go
@@ -299,13 +299,19 @@ func (r *LPTSPuntPoliceResource) Create(ctx context.Context, req resource.Create
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -512,7 +518,6 @@ func (r *LPTSPuntPoliceResource) Update(ctx context.Context, req resource.Update
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -526,6 +531,12 @@ func (r *LPTSPuntPoliceResource) Update(ctx context.Context, req resource.Update
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_mac_set.go
+++ b/internal/provider/resource_iosxr_mac_set.go
@@ -139,13 +139,19 @@ func (r *MacSetResource) Create(ctx context.Context, req resource.CreateRequest,
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *MacSetResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *MacSetResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_macsec.go
+++ b/internal/provider/resource_iosxr_macsec.go
@@ -139,13 +139,19 @@ func (r *MACSecResource) Create(ctx context.Context, req resource.CreateRequest,
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *MACSecResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *MACSecResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_macsec_policy.go
+++ b/internal/provider/resource_iosxr_macsec_policy.go
@@ -274,13 +274,19 @@ func (r *MACSecPolicyResource) Create(ctx context.Context, req resource.CreateRe
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -487,7 +493,6 @@ func (r *MACSecPolicyResource) Update(ctx context.Context, req resource.UpdateRe
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -501,6 +506,12 @@ func (r *MACSecPolicyResource) Update(ctx context.Context, req resource.UpdateRe
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_monitor_session.go
+++ b/internal/provider/resource_iosxr_monitor_session.go
@@ -324,13 +324,19 @@ func (r *MonitorSessionResource) Create(ctx context.Context, req resource.Create
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -537,7 +543,6 @@ func (r *MonitorSessionResource) Update(ctx context.Context, req resource.Update
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -551,6 +556,12 @@ func (r *MonitorSessionResource) Update(ctx context.Context, req resource.Update
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_mpls_ldp.go
+++ b/internal/provider/resource_iosxr_mpls_ldp.go
@@ -402,13 +402,19 @@ func (r *MPLSLDPResource) Create(ctx context.Context, req resource.CreateRequest
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -615,7 +621,6 @@ func (r *MPLSLDPResource) Update(ctx context.Context, req resource.UpdateRequest
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -629,6 +634,12 @@ func (r *MPLSLDPResource) Update(ctx context.Context, req resource.UpdateRequest
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_mpls_ldp_address_family.go
+++ b/internal/provider/resource_iosxr_mpls_ldp_address_family.go
@@ -396,13 +396,19 @@ func (r *MPLSLDPAddressFamilyResource) Create(ctx context.Context, req resource.
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -609,7 +615,6 @@ func (r *MPLSLDPAddressFamilyResource) Update(ctx context.Context, req resource.
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -623,6 +628,12 @@ func (r *MPLSLDPAddressFamilyResource) Update(ctx context.Context, req resource.
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_mpls_ldp_interface.go
+++ b/internal/provider/resource_iosxr_mpls_ldp_interface.go
@@ -210,13 +210,19 @@ func (r *MPLSLDPInterfaceResource) Create(ctx context.Context, req resource.Crea
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -423,7 +429,6 @@ func (r *MPLSLDPInterfaceResource) Update(ctx context.Context, req resource.Upda
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -437,6 +442,12 @@ func (r *MPLSLDPInterfaceResource) Update(ctx context.Context, req resource.Upda
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_mpls_ldp_mldp.go
+++ b/internal/provider/resource_iosxr_mpls_ldp_mldp.go
@@ -292,13 +292,19 @@ func (r *MPLSLDPMLDPResource) Create(ctx context.Context, req resource.CreateReq
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -505,7 +511,6 @@ func (r *MPLSLDPMLDPResource) Update(ctx context.Context, req resource.UpdateReq
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -519,6 +524,12 @@ func (r *MPLSLDPMLDPResource) Update(ctx context.Context, req resource.UpdateReq
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_mpls_ldp_vrf.go
+++ b/internal/provider/resource_iosxr_mpls_ldp_vrf.go
@@ -521,13 +521,19 @@ func (r *MPLSLDPVRFResource) Create(ctx context.Context, req resource.CreateRequ
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -734,7 +740,6 @@ func (r *MPLSLDPVRFResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -748,6 +753,12 @@ func (r *MPLSLDPVRFResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_mpls_oam.go
+++ b/internal/provider/resource_iosxr_mpls_oam.go
@@ -178,13 +178,19 @@ func (r *MPLSOAMResource) Create(ctx context.Context, req resource.CreateRequest
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -391,7 +397,6 @@ func (r *MPLSOAMResource) Update(ctx context.Context, req resource.UpdateRequest
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -405,6 +410,12 @@ func (r *MPLSOAMResource) Update(ctx context.Context, req resource.UpdateRequest
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_mpls_traffic_eng.go
+++ b/internal/provider/resource_iosxr_mpls_traffic_eng.go
@@ -135,13 +135,19 @@ func (r *MPLSTrafficEngResource) Create(ctx context.Context, req resource.Create
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -348,7 +354,6 @@ func (r *MPLSTrafficEngResource) Update(ctx context.Context, req resource.Update
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -362,6 +367,12 @@ func (r *MPLSTrafficEngResource) Update(ctx context.Context, req resource.Update
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_netconf_agent_tty.go
+++ b/internal/provider/resource_iosxr_netconf_agent_tty.go
@@ -160,13 +160,19 @@ func (r *NetconfAgentTTYResource) Create(ctx context.Context, req resource.Creat
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -373,7 +379,6 @@ func (r *NetconfAgentTTYResource) Update(ctx context.Context, req resource.Updat
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -387,6 +392,12 @@ func (r *NetconfAgentTTYResource) Update(ctx context.Context, req resource.Updat
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_netconf_yang_agent.go
+++ b/internal/provider/resource_iosxr_netconf_yang_agent.go
@@ -172,13 +172,19 @@ func (r *NetconfYangAgentResource) Create(ctx context.Context, req resource.Crea
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -385,7 +391,6 @@ func (r *NetconfYangAgentResource) Update(ctx context.Context, req resource.Upda
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -399,6 +404,12 @@ func (r *NetconfYangAgentResource) Update(ctx context.Context, req resource.Upda
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ntp.go
+++ b/internal/provider/resource_iosxr_ntp.go
@@ -1121,13 +1121,19 @@ func (r *NTPResource) Create(ctx context.Context, req resource.CreateRequest, re
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1334,7 +1340,6 @@ func (r *NTPResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1348,6 +1353,12 @@ func (r *NTPResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ospf_area_set.go
+++ b/internal/provider/resource_iosxr_ospf_area_set.go
@@ -139,13 +139,19 @@ func (r *OSPFAreaSetResource) Create(ctx context.Context, req resource.CreateReq
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *OSPFAreaSetResource) Update(ctx context.Context, req resource.UpdateReq
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *OSPFAreaSetResource) Update(ctx context.Context, req resource.UpdateReq
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_pce.go
+++ b/internal/provider/resource_iosxr_pce.go
@@ -1574,13 +1574,19 @@ func (r *PCEResource) Create(ctx context.Context, req resource.CreateRequest, re
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1787,7 +1793,6 @@ func (r *PCEResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1801,6 +1806,12 @@ func (r *PCEResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_performance_measurement.go
+++ b/internal/provider/resource_iosxr_performance_measurement.go
@@ -372,13 +372,19 @@ func (r *PerformanceMeasurementResource) Create(ctx context.Context, req resourc
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -585,7 +591,6 @@ func (r *PerformanceMeasurementResource) Update(ctx context.Context, req resourc
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -599,6 +604,12 @@ func (r *PerformanceMeasurementResource) Update(ctx context.Context, req resourc
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_performance_measurement_delay_profile.go
+++ b/internal/provider/resource_iosxr_performance_measurement_delay_profile.go
@@ -768,13 +768,19 @@ func (r *PerformanceMeasurementDelayProfileResource) Create(ctx context.Context,
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -981,7 +987,6 @@ func (r *PerformanceMeasurementDelayProfileResource) Update(ctx context.Context,
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -995,6 +1000,12 @@ func (r *PerformanceMeasurementDelayProfileResource) Update(ctx context.Context,
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_performance_measurement_endpoint_ipv4.go
+++ b/internal/provider/resource_iosxr_performance_measurement_endpoint_ipv4.go
@@ -253,13 +253,19 @@ func (r *PerformanceMeasurementEndpointIPv4Resource) Create(ctx context.Context,
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -466,7 +472,6 @@ func (r *PerformanceMeasurementEndpointIPv4Resource) Update(ctx context.Context,
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -480,6 +485,12 @@ func (r *PerformanceMeasurementEndpointIPv4Resource) Update(ctx context.Context,
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_performance_measurement_endpoint_ipv6.go
+++ b/internal/provider/resource_iosxr_performance_measurement_endpoint_ipv6.go
@@ -255,13 +255,19 @@ func (r *PerformanceMeasurementEndpointIPv6Resource) Create(ctx context.Context,
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -468,7 +474,6 @@ func (r *PerformanceMeasurementEndpointIPv6Resource) Update(ctx context.Context,
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -482,6 +487,12 @@ func (r *PerformanceMeasurementEndpointIPv6Resource) Update(ctx context.Context,
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_performance_measurement_interface.go
+++ b/internal/provider/resource_iosxr_performance_measurement_interface.go
@@ -217,13 +217,19 @@ func (r *PerformanceMeasurementInterfaceResource) Create(ctx context.Context, re
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -430,7 +436,6 @@ func (r *PerformanceMeasurementInterfaceResource) Update(ctx context.Context, re
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -444,6 +449,12 @@ func (r *PerformanceMeasurementInterfaceResource) Update(ctx context.Context, re
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_performance_measurement_liveness_profile.go
+++ b/internal/provider/resource_iosxr_performance_measurement_liveness_profile.go
@@ -370,13 +370,19 @@ func (r *PerformanceMeasurementLivenessProfileResource) Create(ctx context.Conte
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -583,7 +589,6 @@ func (r *PerformanceMeasurementLivenessProfileResource) Update(ctx context.Conte
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -597,6 +602,12 @@ func (r *PerformanceMeasurementLivenessProfileResource) Update(ctx context.Conte
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_policy_global_set.go
+++ b/internal/provider/resource_iosxr_policy_global_set.go
@@ -126,13 +126,19 @@ func (r *PolicyGlobalSetResource) Create(ctx context.Context, req resource.Creat
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -339,7 +345,6 @@ func (r *PolicyGlobalSetResource) Update(ctx context.Context, req resource.Updat
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -353,6 +358,12 @@ func (r *PolicyGlobalSetResource) Update(ctx context.Context, req resource.Updat
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_policy_map_pbr.go
+++ b/internal/provider/resource_iosxr_policy_map_pbr.go
@@ -273,13 +273,19 @@ func (r *PolicyMapPBRResource) Create(ctx context.Context, req resource.CreateRe
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -486,7 +492,6 @@ func (r *PolicyMapPBRResource) Update(ctx context.Context, req resource.UpdateRe
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -500,6 +505,12 @@ func (r *PolicyMapPBRResource) Update(ctx context.Context, req resource.UpdateRe
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_policy_map_qos.go
+++ b/internal/provider/resource_iosxr_policy_map_qos.go
@@ -532,13 +532,19 @@ func (r *PolicyMapQoSResource) Create(ctx context.Context, req resource.CreateRe
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -745,7 +751,6 @@ func (r *PolicyMapQoSResource) Update(ctx context.Context, req resource.UpdateRe
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -759,6 +764,12 @@ func (r *PolicyMapQoSResource) Update(ctx context.Context, req resource.UpdateRe
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_prefix_set.go
+++ b/internal/provider/resource_iosxr_prefix_set.go
@@ -139,13 +139,19 @@ func (r *PrefixSetResource) Create(ctx context.Context, req resource.CreateReque
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *PrefixSetResource) Update(ctx context.Context, req resource.UpdateReque
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *PrefixSetResource) Update(ctx context.Context, req resource.UpdateReque
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ptp.go
+++ b/internal/provider/resource_iosxr_ptp.go
@@ -464,13 +464,19 @@ func (r *PTPResource) Create(ctx context.Context, req resource.CreateRequest, re
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -677,7 +683,6 @@ func (r *PTPResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -691,6 +696,12 @@ func (r *PTPResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ptp_profile.go
+++ b/internal/provider/resource_iosxr_ptp_profile.go
@@ -760,13 +760,19 @@ func (r *PTPProfileResource) Create(ctx context.Context, req resource.CreateRequ
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -973,7 +979,6 @@ func (r *PTPProfileResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -987,6 +992,12 @@ func (r *PTPProfileResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_radius_server.go
+++ b/internal/provider/resource_iosxr_radius_server.go
@@ -411,13 +411,19 @@ func (r *RadiusServerResource) Create(ctx context.Context, req resource.CreateRe
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -624,7 +630,6 @@ func (r *RadiusServerResource) Update(ctx context.Context, req resource.UpdateRe
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -638,6 +643,12 @@ func (r *RadiusServerResource) Update(ctx context.Context, req resource.UpdateRe
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_radius_source_interface.go
+++ b/internal/provider/resource_iosxr_radius_source_interface.go
@@ -139,13 +139,19 @@ func (r *RadiusSourceInterfaceResource) Create(ctx context.Context, req resource
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *RadiusSourceInterfaceResource) Update(ctx context.Context, req resource
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *RadiusSourceInterfaceResource) Update(ctx context.Context, req resource
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_rd_set.go
+++ b/internal/provider/resource_iosxr_rd_set.go
@@ -139,13 +139,19 @@ func (r *RDSetResource) Create(ctx context.Context, req resource.CreateRequest, 
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *RDSetResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *RDSetResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_route_policy.go
+++ b/internal/provider/resource_iosxr_route_policy.go
@@ -139,13 +139,19 @@ func (r *RoutePolicyResource) Create(ctx context.Context, req resource.CreateReq
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *RoutePolicyResource) Update(ctx context.Context, req resource.UpdateReq
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *RoutePolicyResource) Update(ctx context.Context, req resource.UpdateReq
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_bgp.go
+++ b/internal/provider/resource_iosxr_router_bgp.go
@@ -1547,13 +1547,19 @@ func (r *RouterBGPResource) Create(ctx context.Context, req resource.CreateReque
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1760,7 +1766,6 @@ func (r *RouterBGPResource) Update(ctx context.Context, req resource.UpdateReque
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1774,6 +1779,12 @@ func (r *RouterBGPResource) Update(ctx context.Context, req resource.UpdateReque
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_bgp_address_family.go
+++ b/internal/provider/resource_iosxr_router_bgp_address_family.go
@@ -1355,13 +1355,19 @@ func (r *RouterBGPAddressFamilyResource) Create(ctx context.Context, req resourc
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1568,7 +1574,6 @@ func (r *RouterBGPAddressFamilyResource) Update(ctx context.Context, req resourc
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1582,6 +1587,12 @@ func (r *RouterBGPAddressFamilyResource) Update(ctx context.Context, req resourc
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_bgp_af_group.go
+++ b/internal/provider/resource_iosxr_router_bgp_af_group.go
@@ -579,13 +579,19 @@ func (r *RouterBGPAFGroupResource) Create(ctx context.Context, req resource.Crea
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -792,7 +798,6 @@ func (r *RouterBGPAFGroupResource) Update(ctx context.Context, req resource.Upda
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -806,6 +811,12 @@ func (r *RouterBGPAFGroupResource) Update(ctx context.Context, req resource.Upda
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_bgp_neighbor_address_family.go
+++ b/internal/provider/resource_iosxr_router_bgp_neighbor_address_family.go
@@ -575,13 +575,19 @@ func (r *RouterBGPNeighborAddressFamilyResource) Create(ctx context.Context, req
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -788,7 +794,6 @@ func (r *RouterBGPNeighborAddressFamilyResource) Update(ctx context.Context, req
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -802,6 +807,12 @@ func (r *RouterBGPNeighborAddressFamilyResource) Update(ctx context.Context, req
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_bgp_neighbor_group.go
+++ b/internal/provider/resource_iosxr_router_bgp_neighbor_group.go
@@ -1266,13 +1266,19 @@ func (r *RouterBGPNeighborGroupResource) Create(ctx context.Context, req resourc
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1479,7 +1485,6 @@ func (r *RouterBGPNeighborGroupResource) Update(ctx context.Context, req resourc
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1493,6 +1498,12 @@ func (r *RouterBGPNeighborGroupResource) Update(ctx context.Context, req resourc
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_bgp_session_group.go
+++ b/internal/provider/resource_iosxr_router_bgp_session_group.go
@@ -755,13 +755,19 @@ func (r *RouterBGPSessionGroupResource) Create(ctx context.Context, req resource
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -968,7 +974,6 @@ func (r *RouterBGPSessionGroupResource) Update(ctx context.Context, req resource
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -982,6 +987,12 @@ func (r *RouterBGPSessionGroupResource) Update(ctx context.Context, req resource
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_bgp_vrf.go
+++ b/internal/provider/resource_iosxr_router_bgp_vrf.go
@@ -1154,13 +1154,19 @@ func (r *RouterBGPVRFResource) Create(ctx context.Context, req resource.CreateRe
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1367,7 +1373,6 @@ func (r *RouterBGPVRFResource) Update(ctx context.Context, req resource.UpdateRe
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1381,6 +1386,12 @@ func (r *RouterBGPVRFResource) Update(ctx context.Context, req resource.UpdateRe
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_bgp_vrf_address_family.go
+++ b/internal/provider/resource_iosxr_router_bgp_vrf_address_family.go
@@ -1120,13 +1120,19 @@ func (r *RouterBGPVRFAddressFamilyResource) Create(ctx context.Context, req reso
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1333,7 +1339,6 @@ func (r *RouterBGPVRFAddressFamilyResource) Update(ctx context.Context, req reso
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1347,6 +1352,12 @@ func (r *RouterBGPVRFAddressFamilyResource) Update(ctx context.Context, req reso
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_bgp_vrf_neighbor_address_family.go
+++ b/internal/provider/resource_iosxr_router_bgp_vrf_neighbor_address_family.go
@@ -590,13 +590,19 @@ func (r *RouterBGPVRFNeighborAddressFamilyResource) Create(ctx context.Context, 
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -803,7 +809,6 @@ func (r *RouterBGPVRFNeighborAddressFamilyResource) Update(ctx context.Context, 
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -817,6 +822,12 @@ func (r *RouterBGPVRFNeighborAddressFamilyResource) Update(ctx context.Context, 
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_hsrp_interface.go
+++ b/internal/provider/resource_iosxr_router_hsrp_interface.go
@@ -186,13 +186,19 @@ func (r *RouterHSRPInterfaceResource) Create(ctx context.Context, req resource.C
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -399,7 +405,6 @@ func (r *RouterHSRPInterfaceResource) Update(ctx context.Context, req resource.U
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -413,6 +418,12 @@ func (r *RouterHSRPInterfaceResource) Update(ctx context.Context, req resource.U
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_hsrp_interface_ipv4_group_v1.go
+++ b/internal/provider/resource_iosxr_router_hsrp_interface_ipv4_group_v1.go
@@ -300,13 +300,19 @@ func (r *RouterHSRPInterfaceIPv4GroupV1Resource) Create(ctx context.Context, req
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -513,7 +519,6 @@ func (r *RouterHSRPInterfaceIPv4GroupV1Resource) Update(ctx context.Context, req
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -527,6 +532,12 @@ func (r *RouterHSRPInterfaceIPv4GroupV1Resource) Update(ctx context.Context, req
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_hsrp_interface_ipv4_group_v2.go
+++ b/internal/provider/resource_iosxr_router_hsrp_interface_ipv4_group_v2.go
@@ -300,13 +300,19 @@ func (r *RouterHSRPInterfaceIPv4GroupV2Resource) Create(ctx context.Context, req
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -513,7 +519,6 @@ func (r *RouterHSRPInterfaceIPv4GroupV2Resource) Update(ctx context.Context, req
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -527,6 +532,12 @@ func (r *RouterHSRPInterfaceIPv4GroupV2Resource) Update(ctx context.Context, req
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_hsrp_interface_ipv6_group_v2.go
+++ b/internal/provider/resource_iosxr_router_hsrp_interface_ipv6_group_v2.go
@@ -307,13 +307,19 @@ func (r *RouterHSRPInterfaceIPv6GroupV2Resource) Create(ctx context.Context, req
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -520,7 +526,6 @@ func (r *RouterHSRPInterfaceIPv6GroupV2Resource) Update(ctx context.Context, req
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -534,6 +539,12 @@ func (r *RouterHSRPInterfaceIPv6GroupV2Resource) Update(ctx context.Context, req
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_igmp.go
+++ b/internal/provider/resource_iosxr_router_igmp.go
@@ -301,13 +301,19 @@ func (r *RouterIGMPResource) Create(ctx context.Context, req resource.CreateRequ
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -514,7 +520,6 @@ func (r *RouterIGMPResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -528,6 +533,12 @@ func (r *RouterIGMPResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_igmp_interface.go
+++ b/internal/provider/resource_iosxr_router_igmp_interface.go
@@ -378,13 +378,19 @@ func (r *RouterIGMPInterfaceResource) Create(ctx context.Context, req resource.C
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -591,7 +597,6 @@ func (r *RouterIGMPInterfaceResource) Update(ctx context.Context, req resource.U
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -605,6 +610,12 @@ func (r *RouterIGMPInterfaceResource) Update(ctx context.Context, req resource.U
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_igmp_vrf.go
+++ b/internal/provider/resource_iosxr_router_igmp_vrf.go
@@ -298,13 +298,19 @@ func (r *RouterIGMPVRFResource) Create(ctx context.Context, req resource.CreateR
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -511,7 +517,6 @@ func (r *RouterIGMPVRFResource) Update(ctx context.Context, req resource.UpdateR
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -525,6 +530,12 @@ func (r *RouterIGMPVRFResource) Update(ctx context.Context, req resource.UpdateR
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_igmp_vrf_interface.go
+++ b/internal/provider/resource_iosxr_router_igmp_vrf_interface.go
@@ -389,13 +389,19 @@ func (r *RouterIGMPVRFInterfaceResource) Create(ctx context.Context, req resourc
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -602,7 +608,6 @@ func (r *RouterIGMPVRFInterfaceResource) Update(ctx context.Context, req resourc
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -616,6 +621,12 @@ func (r *RouterIGMPVRFInterfaceResource) Update(ctx context.Context, req resourc
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_isis.go
+++ b/internal/provider/resource_iosxr_router_isis.go
@@ -1225,13 +1225,19 @@ func (r *RouterISISResource) Create(ctx context.Context, req resource.CreateRequ
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1438,7 +1444,6 @@ func (r *RouterISISResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1452,6 +1457,12 @@ func (r *RouterISISResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_isis_address_family.go
+++ b/internal/provider/resource_iosxr_router_isis_address_family.go
@@ -1724,13 +1724,19 @@ func (r *RouterISISAddressFamilyResource) Create(ctx context.Context, req resour
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1937,7 +1943,6 @@ func (r *RouterISISAddressFamilyResource) Update(ctx context.Context, req resour
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1951,6 +1956,12 @@ func (r *RouterISISAddressFamilyResource) Update(ctx context.Context, req resour
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_isis_interface.go
+++ b/internal/provider/resource_iosxr_router_isis_interface.go
@@ -607,13 +607,19 @@ func (r *RouterISISInterfaceResource) Create(ctx context.Context, req resource.C
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -820,7 +826,6 @@ func (r *RouterISISInterfaceResource) Update(ctx context.Context, req resource.U
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -834,6 +839,12 @@ func (r *RouterISISInterfaceResource) Update(ctx context.Context, req resource.U
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_isis_interface_address_family.go
+++ b/internal/provider/resource_iosxr_router_isis_interface_address_family.go
@@ -928,13 +928,19 @@ func (r *RouterISISInterfaceAddressFamilyResource) Create(ctx context.Context, r
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1141,7 +1147,6 @@ func (r *RouterISISInterfaceAddressFamilyResource) Update(ctx context.Context, r
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1155,6 +1160,12 @@ func (r *RouterISISInterfaceAddressFamilyResource) Update(ctx context.Context, r
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_mld.go
+++ b/internal/provider/resource_iosxr_router_mld.go
@@ -284,13 +284,19 @@ func (r *RouterMLDResource) Create(ctx context.Context, req resource.CreateReque
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -497,7 +503,6 @@ func (r *RouterMLDResource) Update(ctx context.Context, req resource.UpdateReque
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -511,6 +516,12 @@ func (r *RouterMLDResource) Update(ctx context.Context, req resource.UpdateReque
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_mld_interface.go
+++ b/internal/provider/resource_iosxr_router_mld_interface.go
@@ -384,13 +384,19 @@ func (r *RouterMLDInterfaceResource) Create(ctx context.Context, req resource.Cr
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -597,7 +603,6 @@ func (r *RouterMLDInterfaceResource) Update(ctx context.Context, req resource.Up
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -611,6 +616,12 @@ func (r *RouterMLDInterfaceResource) Update(ctx context.Context, req resource.Up
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_mld_vrf.go
+++ b/internal/provider/resource_iosxr_router_mld_vrf.go
@@ -288,13 +288,19 @@ func (r *RouterMLDVRFResource) Create(ctx context.Context, req resource.CreateRe
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -501,7 +507,6 @@ func (r *RouterMLDVRFResource) Update(ctx context.Context, req resource.UpdateRe
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -515,6 +520,12 @@ func (r *RouterMLDVRFResource) Update(ctx context.Context, req resource.UpdateRe
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_mld_vrf_interface.go
+++ b/internal/provider/resource_iosxr_router_mld_vrf_interface.go
@@ -396,13 +396,19 @@ func (r *RouterMLDVRFInterfaceResource) Create(ctx context.Context, req resource
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -609,7 +615,6 @@ func (r *RouterMLDVRFInterfaceResource) Update(ctx context.Context, req resource
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -623,6 +628,12 @@ func (r *RouterMLDVRFInterfaceResource) Update(ctx context.Context, req resource
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_ospf.go
+++ b/internal/provider/resource_iosxr_router_ospf.go
@@ -2071,13 +2071,19 @@ func (r *RouterOSPFResource) Create(ctx context.Context, req resource.CreateRequ
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -2284,7 +2290,6 @@ func (r *RouterOSPFResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -2298,6 +2303,12 @@ func (r *RouterOSPFResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_ospf_area.go
+++ b/internal/provider/resource_iosxr_router_ospf_area.go
@@ -1317,13 +1317,19 @@ func (r *RouterOSPFAreaResource) Create(ctx context.Context, req resource.Create
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1530,7 +1536,6 @@ func (r *RouterOSPFAreaResource) Update(ctx context.Context, req resource.Update
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1544,6 +1549,12 @@ func (r *RouterOSPFAreaResource) Update(ctx context.Context, req resource.Update
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_ospf_area_interface.go
+++ b/internal/provider/resource_iosxr_router_ospf_area_interface.go
@@ -922,13 +922,19 @@ func (r *RouterOSPFAreaInterfaceResource) Create(ctx context.Context, req resour
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1135,7 +1141,6 @@ func (r *RouterOSPFAreaInterfaceResource) Update(ctx context.Context, req resour
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1149,6 +1154,12 @@ func (r *RouterOSPFAreaInterfaceResource) Update(ctx context.Context, req resour
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_ospf_vrf.go
+++ b/internal/provider/resource_iosxr_router_ospf_vrf.go
@@ -1748,13 +1748,19 @@ func (r *RouterOSPFVRFResource) Create(ctx context.Context, req resource.CreateR
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1961,7 +1967,6 @@ func (r *RouterOSPFVRFResource) Update(ctx context.Context, req resource.UpdateR
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1975,6 +1980,12 @@ func (r *RouterOSPFVRFResource) Update(ctx context.Context, req resource.UpdateR
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_ospf_vrf_area.go
+++ b/internal/provider/resource_iosxr_router_ospf_vrf_area.go
@@ -974,13 +974,19 @@ func (r *RouterOSPFVRFAreaResource) Create(ctx context.Context, req resource.Cre
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1187,7 +1193,6 @@ func (r *RouterOSPFVRFAreaResource) Update(ctx context.Context, req resource.Upd
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1201,6 +1206,12 @@ func (r *RouterOSPFVRFAreaResource) Update(ctx context.Context, req resource.Upd
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_ospf_vrf_area_interface.go
+++ b/internal/provider/resource_iosxr_router_ospf_vrf_area_interface.go
@@ -887,13 +887,19 @@ func (r *RouterOSPFVRFAreaInterfaceResource) Create(ctx context.Context, req res
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1100,7 +1106,6 @@ func (r *RouterOSPFVRFAreaInterfaceResource) Update(ctx context.Context, req res
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1114,6 +1119,12 @@ func (r *RouterOSPFVRFAreaInterfaceResource) Update(ctx context.Context, req res
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_pim_ipv4.go
+++ b/internal/provider/resource_iosxr_router_pim_ipv4.go
@@ -1371,13 +1371,19 @@ func (r *RouterPIMIPv4Resource) Create(ctx context.Context, req resource.CreateR
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1584,7 +1590,6 @@ func (r *RouterPIMIPv4Resource) Update(ctx context.Context, req resource.UpdateR
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1598,6 +1603,12 @@ func (r *RouterPIMIPv4Resource) Update(ctx context.Context, req resource.UpdateR
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_pim_ipv6.go
+++ b/internal/provider/resource_iosxr_router_pim_ipv6.go
@@ -852,13 +852,19 @@ func (r *RouterPIMIPv6Resource) Create(ctx context.Context, req resource.CreateR
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1065,7 +1071,6 @@ func (r *RouterPIMIPv6Resource) Update(ctx context.Context, req resource.UpdateR
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1079,6 +1084,12 @@ func (r *RouterPIMIPv6Resource) Update(ctx context.Context, req resource.UpdateR
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_pim_vrf_ipv4.go
+++ b/internal/provider/resource_iosxr_router_pim_vrf_ipv4.go
@@ -862,13 +862,19 @@ func (r *RouterPIMVRFIPv4Resource) Create(ctx context.Context, req resource.Crea
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1075,7 +1081,6 @@ func (r *RouterPIMVRFIPv4Resource) Update(ctx context.Context, req resource.Upda
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1089,6 +1094,12 @@ func (r *RouterPIMVRFIPv4Resource) Update(ctx context.Context, req resource.Upda
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_pim_vrf_ipv6.go
+++ b/internal/provider/resource_iosxr_router_pim_vrf_ipv6.go
@@ -772,13 +772,19 @@ func (r *RouterPIMVRFIPv6Resource) Create(ctx context.Context, req resource.Crea
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -985,7 +991,6 @@ func (r *RouterPIMVRFIPv6Resource) Update(ctx context.Context, req resource.Upda
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -999,6 +1004,12 @@ func (r *RouterPIMVRFIPv6Resource) Update(ctx context.Context, req resource.Upda
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_static_ipv4_multicast.go
+++ b/internal/provider/resource_iosxr_router_static_ipv4_multicast.go
@@ -688,13 +688,19 @@ func (r *RouterStaticIPv4MulticastResource) Create(ctx context.Context, req reso
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -901,7 +907,6 @@ func (r *RouterStaticIPv4MulticastResource) Update(ctx context.Context, req reso
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -915,6 +920,12 @@ func (r *RouterStaticIPv4MulticastResource) Update(ctx context.Context, req reso
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_static_ipv4_unicast.go
+++ b/internal/provider/resource_iosxr_router_static_ipv4_unicast.go
@@ -689,13 +689,19 @@ func (r *RouterStaticIPv4UnicastResource) Create(ctx context.Context, req resour
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -902,7 +908,6 @@ func (r *RouterStaticIPv4UnicastResource) Update(ctx context.Context, req resour
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -916,6 +921,12 @@ func (r *RouterStaticIPv4UnicastResource) Update(ctx context.Context, req resour
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_static_ipv6_multicast.go
+++ b/internal/provider/resource_iosxr_router_static_ipv6_multicast.go
@@ -693,13 +693,19 @@ func (r *RouterStaticIPv6MulticastResource) Create(ctx context.Context, req reso
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -906,7 +912,6 @@ func (r *RouterStaticIPv6MulticastResource) Update(ctx context.Context, req reso
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -920,6 +925,12 @@ func (r *RouterStaticIPv6MulticastResource) Update(ctx context.Context, req reso
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_static_ipv6_unicast.go
+++ b/internal/provider/resource_iosxr_router_static_ipv6_unicast.go
@@ -693,13 +693,19 @@ func (r *RouterStaticIPv6UnicastResource) Create(ctx context.Context, req resour
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -906,7 +912,6 @@ func (r *RouterStaticIPv6UnicastResource) Update(ctx context.Context, req resour
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -920,6 +925,12 @@ func (r *RouterStaticIPv6UnicastResource) Update(ctx context.Context, req resour
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_static_vrf_ipv4_multicast.go
+++ b/internal/provider/resource_iosxr_router_static_vrf_ipv4_multicast.go
@@ -699,13 +699,19 @@ func (r *RouterStaticVRFIPv4MulticastResource) Create(ctx context.Context, req r
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -912,7 +918,6 @@ func (r *RouterStaticVRFIPv4MulticastResource) Update(ctx context.Context, req r
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -926,6 +931,12 @@ func (r *RouterStaticVRFIPv4MulticastResource) Update(ctx context.Context, req r
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_static_vrf_ipv4_unicast.go
+++ b/internal/provider/resource_iosxr_router_static_vrf_ipv4_unicast.go
@@ -699,13 +699,19 @@ func (r *RouterStaticVRFIPv4UnicastResource) Create(ctx context.Context, req res
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -912,7 +918,6 @@ func (r *RouterStaticVRFIPv4UnicastResource) Update(ctx context.Context, req res
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -926,6 +931,12 @@ func (r *RouterStaticVRFIPv4UnicastResource) Update(ctx context.Context, req res
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_static_vrf_ipv6_multicast.go
+++ b/internal/provider/resource_iosxr_router_static_vrf_ipv6_multicast.go
@@ -704,13 +704,19 @@ func (r *RouterStaticVRFIPv6MulticastResource) Create(ctx context.Context, req r
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -917,7 +923,6 @@ func (r *RouterStaticVRFIPv6MulticastResource) Update(ctx context.Context, req r
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -931,6 +936,12 @@ func (r *RouterStaticVRFIPv6MulticastResource) Update(ctx context.Context, req r
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_static_vrf_ipv6_unicast.go
+++ b/internal/provider/resource_iosxr_router_static_vrf_ipv6_unicast.go
@@ -704,13 +704,19 @@ func (r *RouterStaticVRFIPv6UnicastResource) Create(ctx context.Context, req res
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -917,7 +923,6 @@ func (r *RouterStaticVRFIPv6UnicastResource) Update(ctx context.Context, req res
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -931,6 +936,12 @@ func (r *RouterStaticVRFIPv6UnicastResource) Update(ctx context.Context, req res
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_vrrp_interface.go
+++ b/internal/provider/resource_iosxr_router_vrrp_interface.go
@@ -178,13 +178,19 @@ func (r *RouterVRRPInterfaceResource) Create(ctx context.Context, req resource.C
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -391,7 +397,6 @@ func (r *RouterVRRPInterfaceResource) Update(ctx context.Context, req resource.U
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -405,6 +410,12 @@ func (r *RouterVRRPInterfaceResource) Update(ctx context.Context, req resource.U
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_vrrp_interface_ipv4.go
+++ b/internal/provider/resource_iosxr_router_vrrp_interface_ipv4.go
@@ -307,13 +307,19 @@ func (r *RouterVRRPInterfaceIPv4Resource) Create(ctx context.Context, req resour
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -520,7 +526,6 @@ func (r *RouterVRRPInterfaceIPv4Resource) Update(ctx context.Context, req resour
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -534,6 +539,12 @@ func (r *RouterVRRPInterfaceIPv4Resource) Update(ctx context.Context, req resour
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_router_vrrp_interface_ipv6.go
+++ b/internal/provider/resource_iosxr_router_vrrp_interface_ipv6.go
@@ -296,13 +296,19 @@ func (r *RouterVRRPInterfaceIPv6Resource) Create(ctx context.Context, req resour
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -509,7 +515,6 @@ func (r *RouterVRRPInterfaceIPv6Resource) Update(ctx context.Context, req resour
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -523,6 +528,12 @@ func (r *RouterVRRPInterfaceIPv6Resource) Update(ctx context.Context, req resour
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_rsvp.go
+++ b/internal/provider/resource_iosxr_rsvp.go
@@ -362,13 +362,19 @@ func (r *RSVPResource) Create(ctx context.Context, req resource.CreateRequest, r
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -575,7 +581,6 @@ func (r *RSVPResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -589,6 +594,12 @@ func (r *RSVPResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_rsvp_interface.go
+++ b/internal/provider/resource_iosxr_rsvp_interface.go
@@ -556,13 +556,19 @@ func (r *RSVPInterfaceResource) Create(ctx context.Context, req resource.CreateR
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -769,7 +775,6 @@ func (r *RSVPInterfaceResource) Update(ctx context.Context, req resource.UpdateR
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -783,6 +788,12 @@ func (r *RSVPInterfaceResource) Update(ctx context.Context, req resource.UpdateR
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_segment_routing.go
+++ b/internal/provider/resource_iosxr_segment_routing.go
@@ -167,13 +167,19 @@ func (r *SegmentRoutingResource) Create(ctx context.Context, req resource.Create
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -380,7 +386,6 @@ func (r *SegmentRoutingResource) Update(ctx context.Context, req resource.Update
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -394,6 +399,12 @@ func (r *SegmentRoutingResource) Update(ctx context.Context, req resource.Update
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_segment_routing_mapping_server.go
+++ b/internal/provider/resource_iosxr_segment_routing_mapping_server.go
@@ -181,13 +181,19 @@ func (r *SegmentRoutingMappingServerResource) Create(ctx context.Context, req re
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -394,7 +400,6 @@ func (r *SegmentRoutingMappingServerResource) Update(ctx context.Context, req re
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -408,6 +413,12 @@ func (r *SegmentRoutingMappingServerResource) Update(ctx context.Context, req re
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_segment_routing_te.go
+++ b/internal/provider/resource_iosxr_segment_routing_te.go
@@ -907,13 +907,19 @@ func (r *SegmentRoutingTEResource) Create(ctx context.Context, req resource.Crea
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1120,7 +1126,6 @@ func (r *SegmentRoutingTEResource) Update(ctx context.Context, req resource.Upda
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1134,6 +1139,12 @@ func (r *SegmentRoutingTEResource) Update(ctx context.Context, req resource.Upda
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_segment_routing_te_on_demand_color.go
+++ b/internal/provider/resource_iosxr_segment_routing_te_on_demand_color.go
@@ -495,13 +495,19 @@ func (r *SegmentRoutingTEOnDemandColorResource) Create(ctx context.Context, req 
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -708,7 +714,6 @@ func (r *SegmentRoutingTEOnDemandColorResource) Update(ctx context.Context, req 
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -722,6 +727,12 @@ func (r *SegmentRoutingTEOnDemandColorResource) Update(ctx context.Context, req 
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_segment_routing_te_policy.go
+++ b/internal/provider/resource_iosxr_segment_routing_te_policy.go
@@ -719,13 +719,19 @@ func (r *SegmentRoutingTEPolicyResource) Create(ctx context.Context, req resourc
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -932,7 +938,6 @@ func (r *SegmentRoutingTEPolicyResource) Update(ctx context.Context, req resourc
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -946,6 +951,12 @@ func (r *SegmentRoutingTEPolicyResource) Update(ctx context.Context, req resourc
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_segment_routing_v6.go
+++ b/internal/provider/resource_iosxr_segment_routing_v6.go
@@ -276,13 +276,19 @@ func (r *SegmentRoutingV6Resource) Create(ctx context.Context, req resource.Crea
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -489,7 +495,6 @@ func (r *SegmentRoutingV6Resource) Update(ctx context.Context, req resource.Upda
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -503,6 +508,12 @@ func (r *SegmentRoutingV6Resource) Update(ctx context.Context, req resource.Upda
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_service_timestamps.go
+++ b/internal/provider/resource_iosxr_service_timestamps.go
@@ -178,13 +178,19 @@ func (r *ServiceTimestampsResource) Create(ctx context.Context, req resource.Cre
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -391,7 +397,6 @@ func (r *ServiceTimestampsResource) Update(ctx context.Context, req resource.Upd
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -405,6 +410,12 @@ func (r *ServiceTimestampsResource) Update(ctx context.Context, req resource.Upd
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_snmp_server.go
+++ b/internal/provider/resource_iosxr_snmp_server.go
@@ -1511,13 +1511,19 @@ func (r *SNMPServerResource) Create(ctx context.Context, req resource.CreateRequ
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1724,7 +1730,6 @@ func (r *SNMPServerResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1738,6 +1743,12 @@ func (r *SNMPServerResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_snmp_server_mib.go
+++ b/internal/provider/resource_iosxr_snmp_server_mib.go
@@ -300,13 +300,19 @@ func (r *SNMPServerMIBResource) Create(ctx context.Context, req resource.CreateR
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -513,7 +519,6 @@ func (r *SNMPServerMIBResource) Update(ctx context.Context, req resource.UpdateR
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -527,6 +532,12 @@ func (r *SNMPServerMIBResource) Update(ctx context.Context, req resource.UpdateR
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_snmp_server_vrf.go
+++ b/internal/provider/resource_iosxr_snmp_server_vrf.go
@@ -372,13 +372,19 @@ func (r *SNMPServerVRFResource) Create(ctx context.Context, req resource.CreateR
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -585,7 +591,6 @@ func (r *SNMPServerVRFResource) Update(ctx context.Context, req resource.UpdateR
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -599,6 +604,12 @@ func (r *SNMPServerVRFResource) Update(ctx context.Context, req resource.UpdateR
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_srlg.go
+++ b/internal/provider/resource_iosxr_srlg.go
@@ -344,13 +344,19 @@ func (r *SRLGResource) Create(ctx context.Context, req resource.CreateRequest, r
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -557,7 +563,6 @@ func (r *SRLGResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -571,6 +576,12 @@ func (r *SRLGResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_ssh.go
+++ b/internal/provider/resource_iosxr_ssh.go
@@ -465,13 +465,19 @@ func (r *SSHResource) Create(ctx context.Context, req resource.CreateRequest, re
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -678,7 +684,6 @@ func (r *SSHResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -692,6 +697,12 @@ func (r *SSHResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_tacacs_server.go
+++ b/internal/provider/resource_iosxr_tacacs_server.go
@@ -238,13 +238,19 @@ func (r *TACACSServerResource) Create(ctx context.Context, req resource.CreateRe
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -451,7 +457,6 @@ func (r *TACACSServerResource) Update(ctx context.Context, req resource.UpdateRe
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -465,6 +470,12 @@ func (r *TACACSServerResource) Update(ctx context.Context, req resource.UpdateRe
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_tacacs_source_interface.go
+++ b/internal/provider/resource_iosxr_tacacs_source_interface.go
@@ -155,13 +155,19 @@ func (r *TACACSSourceInterfaceResource) Create(ctx context.Context, req resource
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -368,7 +374,6 @@ func (r *TACACSSourceInterfaceResource) Update(ctx context.Context, req resource
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -382,6 +387,12 @@ func (r *TACACSSourceInterfaceResource) Update(ctx context.Context, req resource
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_tag_set.go
+++ b/internal/provider/resource_iosxr_tag_set.go
@@ -139,13 +139,19 @@ func (r *TagSetResource) Create(ctx context.Context, req resource.CreateRequest,
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -352,7 +358,6 @@ func (r *TagSetResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -366,6 +371,12 @@ func (r *TagSetResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_tcp.go
+++ b/internal/provider/resource_iosxr_tcp.go
@@ -249,13 +249,19 @@ func (r *TCPResource) Create(ctx context.Context, req resource.CreateRequest, re
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -462,7 +468,6 @@ func (r *TCPResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -476,6 +481,12 @@ func (r *TCPResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_telemetry_model_driven.go
+++ b/internal/provider/resource_iosxr_telemetry_model_driven.go
@@ -496,13 +496,19 @@ func (r *TelemetryModelDrivenResource) Create(ctx context.Context, req resource.
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -709,7 +715,6 @@ func (r *TelemetryModelDrivenResource) Update(ctx context.Context, req resource.
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -723,6 +728,12 @@ func (r *TelemetryModelDrivenResource) Update(ctx context.Context, req resource.
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_telnet.go
+++ b/internal/provider/resource_iosxr_telnet.go
@@ -208,13 +208,19 @@ func (r *TelnetResource) Create(ctx context.Context, req resource.CreateRequest,
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -421,7 +427,6 @@ func (r *TelnetResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -435,6 +440,12 @@ func (r *TelnetResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_tftp_client.go
+++ b/internal/provider/resource_iosxr_tftp_client.go
@@ -174,13 +174,19 @@ func (r *TFTPClientResource) Create(ctx context.Context, req resource.CreateRequ
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -387,7 +393,6 @@ func (r *TFTPClientResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -401,6 +406,12 @@ func (r *TFTPClientResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_tftp_server.go
+++ b/internal/provider/resource_iosxr_tftp_server.go
@@ -194,13 +194,19 @@ func (r *TFTPServerResource) Create(ctx context.Context, req resource.CreateRequ
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -407,7 +413,6 @@ func (r *TFTPServerResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -421,6 +426,12 @@ func (r *TFTPServerResource) Update(ctx context.Context, req resource.UpdateRequ
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_tpa.go
+++ b/internal/provider/resource_iosxr_tpa.go
@@ -291,13 +291,19 @@ func (r *TPAResource) Create(ctx context.Context, req resource.CreateRequest, re
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -504,7 +510,6 @@ func (r *TPAResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -518,6 +523,12 @@ func (r *TPAResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_track.go
+++ b/internal/provider/resource_iosxr_track.go
@@ -555,13 +555,19 @@ func (r *TrackResource) Create(ctx context.Context, req resource.CreateRequest, 
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -768,7 +774,6 @@ func (r *TrackResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -782,6 +787,12 @@ func (r *TrackResource) Update(ctx context.Context, req resource.UpdateRequest, 
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_vrf.go
+++ b/internal/provider/resource_iosxr_vrf.go
@@ -1254,13 +1254,19 @@ func (r *VRFResource) Create(ctx context.Context, req resource.CreateRequest, re
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -1467,7 +1473,6 @@ func (r *VRFResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -1481,6 +1486,12 @@ func (r *VRFResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_vty_pool.go
+++ b/internal/provider/resource_iosxr_vty_pool.go
@@ -206,13 +206,19 @@ func (r *VTYPoolResource) Create(ctx context.Context, req resource.CreateRequest
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -419,7 +425,6 @@ func (r *VTYPoolResource) Update(ctx context.Context, req resource.UpdateRequest
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -433,6 +438,12 @@ func (r *VTYPoolResource) Update(ctx context.Context, req resource.UpdateRequest
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)

--- a/internal/provider/resource_iosxr_xml_agent.go
+++ b/internal/provider/resource_iosxr_xml_agent.go
@@ -308,13 +308,19 @@ func (r *XMLAgentResource) Create(ctx context.Context, req resource.CreateReques
 			// Create object
 			body := plan.toBody(ctx)
 			tflog.Debug(ctx, fmt.Sprintf("gNMI Set body for path %s: %s", plan.getPath(), body))
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			emptyLeafsDelete := plan.getEmptyLeafsDelete(ctx, nil)
 			tflog.Debug(ctx, fmt.Sprintf("List of empty leafs to delete: %+v", emptyLeafsDelete))
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when deletes already carry the intent (IOS-XR
+			// rejects a "{}" update); still send it when it's the only op so bare
+			// containers are created and the SetRequest isn't empty.
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)
@@ -521,7 +527,6 @@ func (r *XMLAgentResource) Update(ctx context.Context, req resource.UpdateReques
 
 			// Update object
 			body := plan.toBody(ctx)
-			ops = append(ops, gnmi.Update(plan.getPath(), body))
 
 			deletedListItems := plan.getDeletedItems(ctx, state)
 			tflog.Debug(ctx, fmt.Sprintf("Removed items to delete: %+v", deletedListItems))
@@ -535,6 +540,12 @@ func (r *XMLAgentResource) Update(ctx context.Context, req resource.UpdateReques
 
 			for _, i := range emptyLeafsDelete {
 				ops = append(ops, gnmi.Delete(i))
+			}
+
+			// Skip an empty "{}" body when other ops carry the intent; still send it
+			// when it's the only op (see Create for rationale).
+			if body != "{}" || len(ops) == 0 {
+				ops = append(ops, gnmi.Update(plan.getPath(), body))
 			}
 
 			_, err := device.GnmiClient.Set(ctx, ops)


### PR DESCRIPTION
## Summary

Two related idempotency fixes for gNMI resources that eliminate spurious plan churn and a device-side rejection on bare/presence-only bodies.

- **`internal/provider/helpers/gnmi.go`** — In `isGnmiGetResponseEmpty`, a gNMI Update entry with a `nil` `Val` is now treated as an existing **bare keyed node** (present, not empty) rather than absent. A truly-absent node still returns zero updates and is handled as empty. This stops constant `+ create` churn for bare `Bundle-Ether`, `Loopback`, `BVI`, `Tunnel`, and subinterface nodes that legitimately exist on the device with no configured leaves.

- **`gen/templates/resource.go`** (+ regenerated `resource_*.go`) — Skip emitting an empty `"{}"` gNMI Update body when delete operations already carry the intent (IOS-XR rejects an update whose body has no leaves). The Update is still sent when it is the sole operation, so bare presence containers such as `iosxr_evpn` are still created and the SetRequest is never empty.

## Testing

- `go build ./...` passes.
- gNMI/Netconf acceptance tests pass.
- Verified bare logical interfaces no longer churn; presence-only update path no longer errors.
