### PR TITLE
fix(provider): document TLS certificate/key attributes as file paths

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -90,12 +90,12 @@ provider "iosxr" {
 
 ### Optional
 
-- `ca_certificate` (String) TLS CA certificate content. This can also be set as the IOSXR_CA_CERTIFICATE environment variable.
-- `certificate` (String) TLS certificate content. This can also be set as the IOSXR_CERTIFICATE environment variable.
+- `ca_certificate` (String) Path to the TLS CA certificate file. This can also be set as the IOSXR_CA_CERTIFICATE environment variable.
+- `certificate` (String) Path to the TLS certificate file. This can also be set as the IOSXR_CERTIFICATE environment variable.
 - `client_cache` (Boolean) Enable or disable client-side caching of device connections. This can improve performance by reusing existing connections. Defaults to `true`.
 - `devices` (Attributes List) This can be used to manage a list of devices from a single provider. All devices must use the same credentials. Each resource and data source has an optional attribute named `device`, which can then select a device by its name from this list. (see [below for nested schema](#nestedatt--devices))
 - `host` (String) Hostname or IP address of the Cisco IOS-XR device. Optionally a port can be added with `:port`. Default port is `57400` for gNMI and `830` for NETCONF. This can also be set as the IOSXR_HOST environment variable.
-- `key` (String) TLS private key content. This can also be set as the IOSXR_KEY environment variable.
+- `key` (String) Path to the TLS private key file. This can also be set as the IOSXR_KEY environment variable.
 - `lock_release_timeout` (Number) Number of seconds to wait for the device database lock to be released. This can also be set as the IOSXR_LOCK_RELEASE_TIMEOUT environment variable. Defaults to `120`.
 - `password` (String, Sensitive) Password for the IOS-XR device. This can also be set as the IOSXR_PASSWORD environment variable.
 - `protocol` (String) Protocol to use for device communication. Either `gnmi` or `netconf` (SSH). This can also be set as the IOSXR_PROTOCOL environment variable. Defaults to `gnmi`.

--- a/gen/templates/provider.go
+++ b/gen/templates/provider.go
@@ -162,15 +162,15 @@ func (p *iosxrProvider) Schema(ctx context.Context, req provider.SchemaRequest, 
 				Optional:            true,
 			},
 			"certificate": schema.StringAttribute{
-				MarkdownDescription: "TLS certificate content. This can also be set as the IOSXR_CERTIFICATE environment variable.",
+				MarkdownDescription: "Path to the TLS certificate file. This can also be set as the IOSXR_CERTIFICATE environment variable.",
 				Optional:            true,
 			},
 			"key": schema.StringAttribute{
-				MarkdownDescription: "TLS private key content. This can also be set as the IOSXR_KEY environment variable.",
+				MarkdownDescription: "Path to the TLS private key file. This can also be set as the IOSXR_KEY environment variable.",
 				Optional:            true,
 			},
 			"ca_certificate": schema.StringAttribute{
-				MarkdownDescription: "TLS CA certificate content. This can also be set as the IOSXR_CA_CERTIFICATE environment variable.",
+				MarkdownDescription: "Path to the TLS CA certificate file. This can also be set as the IOSXR_CA_CERTIFICATE environment variable.",
 				Optional:            true,
 			},
 			"retries": schema.Int64Attribute{

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -160,15 +160,15 @@ func (p *iosxrProvider) Schema(ctx context.Context, req provider.SchemaRequest, 
 				Optional:            true,
 			},
 			"certificate": schema.StringAttribute{
-				MarkdownDescription: "TLS certificate content. This can also be set as the IOSXR_CERTIFICATE environment variable.",
+				MarkdownDescription: "Path to the TLS certificate file. This can also be set as the IOSXR_CERTIFICATE environment variable.",
 				Optional:            true,
 			},
 			"key": schema.StringAttribute{
-				MarkdownDescription: "TLS private key content. This can also be set as the IOSXR_KEY environment variable.",
+				MarkdownDescription: "Path to the TLS private key file. This can also be set as the IOSXR_KEY environment variable.",
 				Optional:            true,
 			},
 			"ca_certificate": schema.StringAttribute{
-				MarkdownDescription: "TLS CA certificate content. This can also be set as the IOSXR_CA_CERTIFICATE environment variable.",
+				MarkdownDescription: "Path to the TLS CA certificate file. This can also be set as the IOSXR_CA_CERTIFICATE environment variable.",
 				Optional:            true,
 			},
 			"retries": schema.Int64Attribute{


### PR DESCRIPTION
## Summary

The `ca_certificate`, `certificate`, and `key` provider attributes are documented as certificate/key **content**, but they are actually **file paths**. The values are passed to go-gnmi's `TLSCert`/`TLSKey`/`TLSCA` options, which expect filesystem paths (the client validates them via `os.Stat` and returns "file not found" errors), not inline PEM content.

This updates the schema descriptions in the generator template and regenerates the Go provider schema and provider docs to match actual behavior.

## Changes

- `gen/templates/provider.go` — corrected `MarkdownDescription` for `certificate`, `key`, `ca_certificate`
- `internal/provider/provider.go` — regenerated
- `docs/index.md` — regenerated

Old: `TLS certificate content. ...`
New: `Path to the TLS certificate file. ...`

## Test plan

- [x] `go generate ./...` produces no unrelated diff
- [x] No remaining "TLS ... content" wording in `gen/`, `internal/`, `docs/`