### PR TITLE
fix(netconf): fix keys-only container create drift and banner trailing newline

### DIFF
--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -2340,6 +2340,19 @@ func (data {{camelCase .Name}}) toBodyXML(ctx context.Context, stateArg ...*{{ca
 	{{- end}}
 	{{- end}}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -2403,8 +2403,8 @@ func (data *{{camelCase .Name}}) updateFromBodyXML(ctx context.Context, res xmld
 	{{- end}}
 	{{- else if eq .Type "String"}}
 	if value := helpers.GetFromXPath(res, "data/" + data.getXPath() + "/{{.XPath}}"); value.Exists() && !data.{{toGoName .TfName}}.IsNull() {
-		{{- if or (eq .TfName "rpl") (hasPrefix .YangName "rpl")}}
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		{{- if or (eq .TfName "rpl") (hasPrefix .YangName "rpl") (and (eq $.Name "Banner") (eq .TfName "line"))}}
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := {{if .ReadRaw}}value.Raw{{else}}value.String(){{end}}
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -2673,8 +2673,8 @@ func (data *{{camelCase .Name}}) fromBodyXML(ctx context.Context, res xmldot.Res
 	}
 	{{- else if eq .Type "String"}}
 	if value := helpers.GetFromXPath(res, "data/" + data.getXPath() + "/{{.XPath}}"); value.Exists() {
-		{{- if or (eq .TfName "rpl") (hasPrefix .YangName "rpl")}}
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		{{- if or (eq .TfName "rpl") (hasPrefix .YangName "rpl") (and (eq $.Name "Banner") (eq .TfName "line"))}}
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := {{if .ReadRaw}}value.Raw{{else}}value.String(){{end}}
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -2971,8 +2971,8 @@ func (data *{{camelCase .Name}}Data) fromBodyXML(ctx context.Context, res xmldot
 	}
 	{{- else if eq .Type "String"}}
 	if value := helpers.GetFromXPath(res, "data/" + data.getXPath() + "/{{.XPath}}"); value.Exists() {
-		{{- if or (eq .TfName "rpl") (hasPrefix .YangName "rpl")}}
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		{{- if or (eq .TfName "rpl") (hasPrefix .YangName "rpl") (and (eq $.Name "Banner") (eq .TfName "line"))}}
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := {{if .ReadRaw}}value.Raw{{else}}value.String(){{end}}
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_aaa.go
+++ b/internal/provider/model_iosxr_aaa.go
@@ -4985,6 +4985,19 @@ func (data AAA) toBodyXML(ctx context.Context, stateArg ...*AAA) string {
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_aaa_accounting.go
+++ b/internal/provider/model_iosxr_aaa_accounting.go
@@ -976,6 +976,19 @@ func (data AAAAccounting) toBodyXML(ctx context.Context, stateArg ...*AAAAccount
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_aaa_authentication.go
+++ b/internal/provider/model_iosxr_aaa_authentication.go
@@ -324,6 +324,19 @@ func (data AAAAuthentication) toBodyXML(ctx context.Context, stateArg ...*AAAAut
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_aaa_authorization.go
+++ b/internal/provider/model_iosxr_aaa_authorization.go
@@ -809,6 +809,19 @@ func (data AAAAuthorization) toBodyXML(ctx context.Context, stateArg ...*AAAAuth
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_as_path_set.go
+++ b/internal/provider/model_iosxr_as_path_set.go
@@ -112,6 +112,19 @@ func (data ASPathSet) toBodyXML(ctx context.Context, stateArg ...*ASPathSet) str
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_as_path_set.go
+++ b/internal/provider/model_iosxr_as_path_set.go
@@ -151,7 +151,7 @@ func (data *ASPathSet) updateFromBody(ctx context.Context, res gjson.Result) {
 
 func (data *ASPathSet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rplas-path-set"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -205,7 +205,7 @@ func (data *ASPathSetData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *ASPathSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rplas-path-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -220,7 +220,7 @@ func (data *ASPathSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 
 func (data *ASPathSetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rplas-path-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_banner.go
+++ b/internal/provider/model_iosxr_banner.go
@@ -151,7 +151,12 @@ func (data *Banner) updateFromBody(ctx context.Context, res gjson.Result) {
 
 func (data *Banner) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/line"); value.Exists() && !data.Line.IsNull() {
-		data.Line = types.StringValue(value.String())
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
+		rplValue := value.String()
+		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
+			rplValue = rplValue + "\n"
+		}
+		data.Line = types.StringValue(rplValue)
 	} else if data.Line.IsNull() {
 		data.Line = types.StringNull()
 	}
@@ -200,7 +205,12 @@ func (data *BannerData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *Banner) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/line"); value.Exists() {
-		data.Line = types.StringValue(value.String())
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
+		rplValue := value.String()
+		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
+			rplValue = rplValue + "\n"
+		}
+		data.Line = types.StringValue(rplValue)
 	}
 }
 
@@ -210,7 +220,12 @@ func (data *Banner) fromBodyXML(ctx context.Context, res xmldot.Result) {
 
 func (data *BannerData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/line"); value.Exists() {
-		data.Line = types.StringValue(value.String())
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
+		rplValue := value.String()
+		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
+			rplValue = rplValue + "\n"
+		}
+		data.Line = types.StringValue(rplValue)
 	}
 }
 

--- a/internal/provider/model_iosxr_banner.go
+++ b/internal/provider/model_iosxr_banner.go
@@ -112,6 +112,19 @@ func (data Banner) toBodyXML(ctx context.Context, stateArg ...*Banner) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_bfd.go
+++ b/internal/provider/model_iosxr_bfd.go
@@ -435,6 +435,19 @@ func (data BFD) toBodyXML(ctx context.Context, stateArg ...*BFD) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_bmp_server.go
+++ b/internal/provider/model_iosxr_bmp_server.go
@@ -296,6 +296,19 @@ func (data BMPServer) toBodyXML(ctx context.Context, stateArg ...*BMPServer) str
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_call_home.go
+++ b/internal/provider/model_iosxr_call_home.go
@@ -511,6 +511,19 @@ func (data CallHome) toBodyXML(ctx context.Context, stateArg ...*CallHome) strin
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_cdp.go
+++ b/internal/provider/model_iosxr_cdp.go
@@ -152,6 +152,19 @@ func (data CDP) toBodyXML(ctx context.Context, stateArg ...*CDP) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_cef.go
+++ b/internal/provider/model_iosxr_cef.go
@@ -240,6 +240,19 @@ func (data CEF) toBodyXML(ctx context.Context, stateArg ...*CEF) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_cef_load_balancing_8000.go
+++ b/internal/provider/model_iosxr_cef_load_balancing_8000.go
@@ -330,6 +330,19 @@ func (data CEFLoadBalancing8000) toBodyXML(ctx context.Context, stateArg ...*CEF
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_cef_pbts_forward_class.go
+++ b/internal/provider/model_iosxr_cef_pbts_forward_class.go
@@ -142,6 +142,19 @@ func (data CEFPBTSForwardClass) toBodyXML(ctx context.Context, stateArg ...*CEFP
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_class_map_qos.go
+++ b/internal/provider/model_iosxr_class_map_qos.go
@@ -684,6 +684,19 @@ func (data ClassMapQoS) toBodyXML(ctx context.Context, stateArg ...*ClassMapQoS)
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_class_map_traffic.go
+++ b/internal/provider/model_iosxr_class_map_traffic.go
@@ -656,6 +656,19 @@ func (data ClassMapTraffic) toBodyXML(ctx context.Context, stateArg ...*ClassMap
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_cli_alias.go
+++ b/internal/provider/model_iosxr_cli_alias.go
@@ -183,6 +183,19 @@ func (data CLIAlias) toBodyXML(ctx context.Context, stateArg ...*CLIAlias) strin
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_community_set.go
+++ b/internal/provider/model_iosxr_community_set.go
@@ -112,6 +112,19 @@ func (data CommunitySet) toBodyXML(ctx context.Context, stateArg ...*CommunitySe
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_community_set.go
+++ b/internal/provider/model_iosxr_community_set.go
@@ -151,7 +151,7 @@ func (data *CommunitySet) updateFromBody(ctx context.Context, res gjson.Result) 
 
 func (data *CommunitySet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-community-set"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -205,7 +205,7 @@ func (data *CommunitySetData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *CommunitySet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-community-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -220,7 +220,7 @@ func (data *CommunitySet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 
 func (data *CommunitySetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-community-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_control_plane.go
+++ b/internal/provider/model_iosxr_control_plane.go
@@ -3350,6 +3350,19 @@ func (data ControlPlane) toBodyXML(ctx context.Context, stateArg ...*ControlPlan
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_controller_optics.go
+++ b/internal/provider/model_iosxr_controller_optics.go
@@ -202,6 +202,19 @@ func (data ControllerOptics) toBodyXML(ctx context.Context, stateArg ...*Control
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_crypto.go
+++ b/internal/provider/model_iosxr_crypto.go
@@ -758,6 +758,19 @@ func (data Crypto) toBodyXML(ctx context.Context, stateArg ...*Crypto) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_domain.go
+++ b/internal/provider/model_iosxr_domain.go
@@ -272,6 +272,19 @@ func (data Domain) toBodyXML(ctx context.Context, stateArg ...*Domain) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_domain_vrf.go
+++ b/internal/provider/model_iosxr_domain_vrf.go
@@ -267,6 +267,19 @@ func (data DomainVRF) toBodyXML(ctx context.Context, stateArg ...*DomainVRF) str
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_error_disable_recovery.go
+++ b/internal/provider/model_iosxr_error_disable_recovery.go
@@ -259,6 +259,19 @@ func (data ErrorDisableRecovery) toBodyXML(ctx context.Context, stateArg ...*Err
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_esi_set.go
+++ b/internal/provider/model_iosxr_esi_set.go
@@ -151,7 +151,7 @@ func (data *ESISet) updateFromBody(ctx context.Context, res gjson.Result) {
 
 func (data *ESISet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/esi-set-as-text"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -205,7 +205,7 @@ func (data *ESISetData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *ESISet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/esi-set-as-text"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -220,7 +220,7 @@ func (data *ESISet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 
 func (data *ESISetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/esi-set-as-text"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_esi_set.go
+++ b/internal/provider/model_iosxr_esi_set.go
@@ -112,6 +112,19 @@ func (data ESISet) toBodyXML(ctx context.Context, stateArg ...*ESISet) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_etag_set.go
+++ b/internal/provider/model_iosxr_etag_set.go
@@ -112,6 +112,19 @@ func (data EtagSet) toBodyXML(ctx context.Context, stateArg ...*EtagSet) string 
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_etag_set.go
+++ b/internal/provider/model_iosxr_etag_set.go
@@ -151,7 +151,7 @@ func (data *EtagSet) updateFromBody(ctx context.Context, res gjson.Result) {
 
 func (data *EtagSet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/etag-set-as-text"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -205,7 +205,7 @@ func (data *EtagSetData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *EtagSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/etag-set-as-text"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -220,7 +220,7 @@ func (data *EtagSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 
 func (data *EtagSetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/etag-set-as-text"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_ethernet_cfm.go
+++ b/internal/provider/model_iosxr_ethernet_cfm.go
@@ -704,6 +704,19 @@ func (data EthernetCFM) toBodyXML(ctx context.Context, stateArg ...*EthernetCFM)
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_ethernet_sla.go
+++ b/internal/provider/model_iosxr_ethernet_sla.go
@@ -535,6 +535,19 @@ func (data EthernetSLA) toBodyXML(ctx context.Context, stateArg ...*EthernetSLA)
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_evpn.go
+++ b/internal/provider/model_iosxr_evpn.go
@@ -793,6 +793,19 @@ func (data EVPN) toBodyXML(ctx context.Context, stateArg ...*EVPN) string {
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_evpn_evi.go
+++ b/internal/provider/model_iosxr_evpn_evi.go
@@ -727,6 +727,19 @@ func (data EVPNEVI) toBodyXML(ctx context.Context, stateArg ...*EVPNEVI) string 
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_evpn_interface.go
+++ b/internal/provider/model_iosxr_evpn_interface.go
@@ -343,6 +343,19 @@ func (data EVPNInterface) toBodyXML(ctx context.Context, stateArg ...*EVPNInterf
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_evpn_route_sync_evi.go
+++ b/internal/provider/model_iosxr_evpn_route_sync_evi.go
@@ -427,6 +427,19 @@ func (data EVPNRouteSyncEVI) toBodyXML(ctx context.Context, stateArg ...*EVPNRou
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_evpn_route_sync_stitching_evi.go
+++ b/internal/provider/model_iosxr_evpn_route_sync_stitching_evi.go
@@ -427,6 +427,19 @@ func (data EVPNRouteSyncStitchingEVI) toBodyXML(ctx context.Context, stateArg ..
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_evpn_segment_routing_srv6_evi.go
+++ b/internal/provider/model_iosxr_evpn_segment_routing_srv6_evi.go
@@ -675,6 +675,19 @@ func (data EVPNSegmentRoutingSRv6EVI) toBodyXML(ctx context.Context, stateArg ..
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_evpn_segment_routing_srv6_stitching_evi.go
+++ b/internal/provider/model_iosxr_evpn_segment_routing_srv6_stitching_evi.go
@@ -591,6 +591,19 @@ func (data EVPNSegmentRoutingSRv6StitchingEVI) toBodyXML(ctx context.Context, st
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_evpn_stitching_evi.go
+++ b/internal/provider/model_iosxr_evpn_stitching_evi.go
@@ -727,6 +727,19 @@ func (data EVPNStitchingEVI) toBodyXML(ctx context.Context, stateArg ...*EVPNSti
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_evpn_stitching_vni.go
+++ b/internal/provider/model_iosxr_evpn_stitching_vni.go
@@ -487,6 +487,19 @@ func (data EVPNStitchingVNI) toBodyXML(ctx context.Context, stateArg ...*EVPNSti
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_evpn_vni.go
+++ b/internal/provider/model_iosxr_evpn_vni.go
@@ -487,6 +487,19 @@ func (data EVPNVNI) toBodyXML(ctx context.Context, stateArg ...*EVPNVNI) string 
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_extcommunity_bandwidth_set.go
+++ b/internal/provider/model_iosxr_extcommunity_bandwidth_set.go
@@ -151,7 +151,7 @@ func (data *ExtcommunityBandwidthSet) updateFromBody(ctx context.Context, res gj
 
 func (data *ExtcommunityBandwidthSet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-bandwidth-set"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -205,7 +205,7 @@ func (data *ExtcommunityBandwidthSetData) fromBody(ctx context.Context, res gjso
 
 func (data *ExtcommunityBandwidthSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-bandwidth-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -220,7 +220,7 @@ func (data *ExtcommunityBandwidthSet) fromBodyXML(ctx context.Context, res xmldo
 
 func (data *ExtcommunityBandwidthSetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-bandwidth-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_extcommunity_bandwidth_set.go
+++ b/internal/provider/model_iosxr_extcommunity_bandwidth_set.go
@@ -112,6 +112,19 @@ func (data ExtcommunityBandwidthSet) toBodyXML(ctx context.Context, stateArg ...
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_extcommunity_cost_set.go
+++ b/internal/provider/model_iosxr_extcommunity_cost_set.go
@@ -112,6 +112,19 @@ func (data ExtcommunityCostSet) toBodyXML(ctx context.Context, stateArg ...*Extc
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_extcommunity_cost_set.go
+++ b/internal/provider/model_iosxr_extcommunity_cost_set.go
@@ -151,7 +151,7 @@ func (data *ExtcommunityCostSet) updateFromBody(ctx context.Context, res gjson.R
 
 func (data *ExtcommunityCostSet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-cost-set"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -205,7 +205,7 @@ func (data *ExtcommunityCostSetData) fromBody(ctx context.Context, res gjson.Res
 
 func (data *ExtcommunityCostSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-cost-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -220,7 +220,7 @@ func (data *ExtcommunityCostSet) fromBodyXML(ctx context.Context, res xmldot.Res
 
 func (data *ExtcommunityCostSetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-cost-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_extcommunity_evpn_link_bandwidth_set.go
+++ b/internal/provider/model_iosxr_extcommunity_evpn_link_bandwidth_set.go
@@ -151,7 +151,7 @@ func (data *ExtcommunityEVPNLinkBandwidthSet) updateFromBody(ctx context.Context
 
 func (data *ExtcommunityEVPNLinkBandwidthSet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-evpn-bandwidth-set"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -205,7 +205,7 @@ func (data *ExtcommunityEVPNLinkBandwidthSetData) fromBody(ctx context.Context, 
 
 func (data *ExtcommunityEVPNLinkBandwidthSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-evpn-bandwidth-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -220,7 +220,7 @@ func (data *ExtcommunityEVPNLinkBandwidthSet) fromBodyXML(ctx context.Context, r
 
 func (data *ExtcommunityEVPNLinkBandwidthSetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-evpn-bandwidth-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_extcommunity_evpn_link_bandwidth_set.go
+++ b/internal/provider/model_iosxr_extcommunity_evpn_link_bandwidth_set.go
@@ -112,6 +112,19 @@ func (data ExtcommunityEVPNLinkBandwidthSet) toBodyXML(ctx context.Context, stat
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_extcommunity_opaque_set.go
+++ b/internal/provider/model_iosxr_extcommunity_opaque_set.go
@@ -151,7 +151,7 @@ func (data *ExtcommunityOpaqueSet) updateFromBody(ctx context.Context, res gjson
 
 func (data *ExtcommunityOpaqueSet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-opaque-set"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -205,7 +205,7 @@ func (data *ExtcommunityOpaqueSetData) fromBody(ctx context.Context, res gjson.R
 
 func (data *ExtcommunityOpaqueSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-opaque-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -220,7 +220,7 @@ func (data *ExtcommunityOpaqueSet) fromBodyXML(ctx context.Context, res xmldot.R
 
 func (data *ExtcommunityOpaqueSetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-opaque-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_extcommunity_opaque_set.go
+++ b/internal/provider/model_iosxr_extcommunity_opaque_set.go
@@ -112,6 +112,19 @@ func (data ExtcommunityOpaqueSet) toBodyXML(ctx context.Context, stateArg ...*Ex
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_extcommunity_rt_set.go
+++ b/internal/provider/model_iosxr_extcommunity_rt_set.go
@@ -112,6 +112,19 @@ func (data ExtcommunityRTSet) toBodyXML(ctx context.Context, stateArg ...*Extcom
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_extcommunity_rt_set.go
+++ b/internal/provider/model_iosxr_extcommunity_rt_set.go
@@ -151,7 +151,7 @@ func (data *ExtcommunityRTSet) updateFromBody(ctx context.Context, res gjson.Res
 
 func (data *ExtcommunityRTSet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-rt-set"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -205,7 +205,7 @@ func (data *ExtcommunityRTSetData) fromBody(ctx context.Context, res gjson.Resul
 
 func (data *ExtcommunityRTSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-rt-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -220,7 +220,7 @@ func (data *ExtcommunityRTSet) fromBodyXML(ctx context.Context, res xmldot.Resul
 
 func (data *ExtcommunityRTSetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-rt-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_extcommunity_seg_nh_set.go
+++ b/internal/provider/model_iosxr_extcommunity_seg_nh_set.go
@@ -151,7 +151,7 @@ func (data *ExtcommunitySegNHSet) updateFromBody(ctx context.Context, res gjson.
 
 func (data *ExtcommunitySegNHSet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-seg-nh-set"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -205,7 +205,7 @@ func (data *ExtcommunitySegNHSetData) fromBody(ctx context.Context, res gjson.Re
 
 func (data *ExtcommunitySegNHSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-seg-nh-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -220,7 +220,7 @@ func (data *ExtcommunitySegNHSet) fromBodyXML(ctx context.Context, res xmldot.Re
 
 func (data *ExtcommunitySegNHSetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-seg-nh-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_extcommunity_seg_nh_set.go
+++ b/internal/provider/model_iosxr_extcommunity_seg_nh_set.go
@@ -112,6 +112,19 @@ func (data ExtcommunitySegNHSet) toBodyXML(ctx context.Context, stateArg ...*Ext
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_extcommunity_soo_set.go
+++ b/internal/provider/model_iosxr_extcommunity_soo_set.go
@@ -112,6 +112,19 @@ func (data ExtcommunitySOOSet) toBodyXML(ctx context.Context, stateArg ...*Extco
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_extcommunity_soo_set.go
+++ b/internal/provider/model_iosxr_extcommunity_soo_set.go
@@ -151,7 +151,7 @@ func (data *ExtcommunitySOOSet) updateFromBody(ctx context.Context, res gjson.Re
 
 func (data *ExtcommunitySOOSet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-soo-set"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -205,7 +205,7 @@ func (data *ExtcommunitySOOSetData) fromBody(ctx context.Context, res gjson.Resu
 
 func (data *ExtcommunitySOOSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-soo-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -220,7 +220,7 @@ func (data *ExtcommunitySOOSet) fromBodyXML(ctx context.Context, res xmldot.Resu
 
 func (data *ExtcommunitySOOSetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-extended-community-soo-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_flow_exporter_map.go
+++ b/internal/provider/model_iosxr_flow_exporter_map.go
@@ -269,6 +269,19 @@ func (data FlowExporterMap) toBodyXML(ctx context.Context, stateArg ...*FlowExpo
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_flow_monitor_map.go
+++ b/internal/provider/model_iosxr_flow_monitor_map.go
@@ -767,6 +767,19 @@ func (data FlowMonitorMap) toBodyXML(ctx context.Context, stateArg ...*FlowMonit
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_flow_sampler_map.go
+++ b/internal/provider/model_iosxr_flow_sampler_map.go
@@ -121,6 +121,19 @@ func (data FlowSamplerMap) toBodyXML(ctx context.Context, stateArg ...*FlowSampl
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_fpd.go
+++ b/internal/provider/model_iosxr_fpd.go
@@ -146,6 +146,19 @@ func (data FPD) toBodyXML(ctx context.Context, stateArg ...*FPD) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_frequency_synchronization.go
+++ b/internal/provider/model_iosxr_frequency_synchronization.go
@@ -214,6 +214,19 @@ func (data FrequencySynchronization) toBodyXML(ctx context.Context, stateArg ...
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_ftp.go
+++ b/internal/provider/model_iosxr_ftp.go
@@ -159,6 +159,19 @@ func (data FTP) toBodyXML(ctx context.Context, stateArg ...*FTP) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_generic_interface_list.go
+++ b/internal/provider/model_iosxr_generic_interface_list.go
@@ -127,6 +127,19 @@ func (data GenericInterfaceList) toBodyXML(ctx context.Context, stateArg ...*Gen
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_hostname.go
+++ b/internal/provider/model_iosxr_hostname.go
@@ -105,6 +105,19 @@ func (data Hostname) toBodyXML(ctx context.Context, stateArg ...*Hostname) strin
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_hw_module_profile.go
+++ b/internal/provider/model_iosxr_hw_module_profile.go
@@ -1778,6 +1778,19 @@ func (data HWModuleProfile) toBodyXML(ctx context.Context, stateArg ...*HWModule
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_hw_module_profile_8000.go
+++ b/internal/provider/model_iosxr_hw_module_profile_8000.go
@@ -2292,6 +2292,19 @@ func (data HWModuleProfile8000) toBodyXML(ctx context.Context, stateArg ...*HWMo
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_hw_module_shutdown.go
+++ b/internal/provider/model_iosxr_hw_module_shutdown.go
@@ -156,6 +156,19 @@ func (data HWModuleShutdown) toBodyXML(ctx context.Context, stateArg ...*HWModul
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_icmp.go
+++ b/internal/provider/model_iosxr_icmp.go
@@ -270,6 +270,19 @@ func (data ICMP) toBodyXML(ctx context.Context, stateArg ...*ICMP) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_interface_bundle_ether.go
+++ b/internal/provider/model_iosxr_interface_bundle_ether.go
@@ -11692,6 +11692,19 @@ func (data InterfaceBundleEther) toBodyXML(ctx context.Context, stateArg ...*Int
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_interface_bundle_ether_subinterface.go
+++ b/internal/provider/model_iosxr_interface_bundle_ether_subinterface.go
@@ -5402,6 +5402,19 @@ func (data InterfaceBundleEtherSubinterface) toBodyXML(ctx context.Context, stat
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_interface_bvi.go
+++ b/internal/provider/model_iosxr_interface_bvi.go
@@ -4295,6 +4295,19 @@ func (data InterfaceBVI) toBodyXML(ctx context.Context, stateArg ...*InterfaceBV
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_interface_ethernet.go
+++ b/internal/provider/model_iosxr_interface_ethernet.go
@@ -6208,6 +6208,19 @@ func (data InterfaceEthernet) toBodyXML(ctx context.Context, stateArg ...*Interf
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_interface_ethernet_subinterface.go
+++ b/internal/provider/model_iosxr_interface_ethernet_subinterface.go
@@ -5520,6 +5520,19 @@ func (data InterfaceEthernetSubinterface) toBodyXML(ctx context.Context, stateAr
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_interface_loopback.go
+++ b/internal/provider/model_iosxr_interface_loopback.go
@@ -1152,6 +1152,19 @@ func (data InterfaceLoopback) toBodyXML(ctx context.Context, stateArg ...*Interf
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_interface_tunnel_ip.go
+++ b/internal/provider/model_iosxr_interface_tunnel_ip.go
@@ -1076,6 +1076,19 @@ func (data InterfaceTunnelIP) toBodyXML(ctx context.Context, stateArg ...*Interf
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_interface_tunnel_te.go
+++ b/internal/provider/model_iosxr_interface_tunnel_te.go
@@ -2391,6 +2391,19 @@ func (data InterfaceTunnelTE) toBodyXML(ctx context.Context, stateArg ...*Interf
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_ipsla.go
+++ b/internal/provider/model_iosxr_ipsla.go
@@ -2287,6 +2287,19 @@ func (data IPSLA) toBodyXML(ctx context.Context, stateArg ...*IPSLA) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_ipsla_responder.go
+++ b/internal/provider/model_iosxr_ipsla_responder.go
@@ -612,6 +612,19 @@ func (data IPSLAResponder) toBodyXML(ctx context.Context, stateArg ...*IPSLAResp
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_ipv4_access_list.go
+++ b/internal/provider/model_iosxr_ipv4_access_list.go
@@ -2389,6 +2389,19 @@ func (data IPv4AccessList) toBodyXML(ctx context.Context, stateArg ...*IPv4Acces
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_ipv4_access_list_options.go
+++ b/internal/provider/model_iosxr_ipv4_access_list_options.go
@@ -139,6 +139,19 @@ func (data IPv4AccessListOptions) toBodyXML(ctx context.Context, stateArg ...*IP
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_ipv4_prefix_list.go
+++ b/internal/provider/model_iosxr_ipv4_prefix_list.go
@@ -175,6 +175,19 @@ func (data IPv4PrefixList) toBodyXML(ctx context.Context, stateArg ...*IPv4Prefi
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_ipv6.go
+++ b/internal/provider/model_iosxr_ipv6.go
@@ -208,6 +208,19 @@ func (data IPv6) toBodyXML(ctx context.Context, stateArg ...*IPv6) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_ipv6_access_list.go
+++ b/internal/provider/model_iosxr_ipv6_access_list.go
@@ -2045,6 +2045,19 @@ func (data IPv6AccessList) toBodyXML(ctx context.Context, stateArg ...*IPv6Acces
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_ipv6_access_list_options.go
+++ b/internal/provider/model_iosxr_ipv6_access_list_options.go
@@ -177,6 +177,19 @@ func (data IPv6AccessListOptions) toBodyXML(ctx context.Context, stateArg ...*IP
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_ipv6_prefix_list.go
+++ b/internal/provider/model_iosxr_ipv6_prefix_list.go
@@ -182,6 +182,19 @@ func (data IPv6PrefixList) toBodyXML(ctx context.Context, stateArg ...*IPv6Prefi
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_key_chain.go
+++ b/internal/provider/model_iosxr_key_chain.go
@@ -883,6 +883,19 @@ func (data KeyChain) toBodyXML(ctx context.Context, stateArg ...*KeyChain) strin
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_l2vpn.go
+++ b/internal/provider/model_iosxr_l2vpn.go
@@ -1086,6 +1086,19 @@ func (data L2VPN) toBodyXML(ctx context.Context, stateArg ...*L2VPN) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_l2vpn_bridge_group_bridge_domain.go
+++ b/internal/provider/model_iosxr_l2vpn_bridge_group_bridge_domain.go
@@ -2661,6 +2661,19 @@ func (data L2VPNBridgeGroupBridgeDomain) toBodyXML(ctx context.Context, stateArg
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_l2vpn_bridge_group_bridge_domain_access_vfi.go
+++ b/internal/provider/model_iosxr_l2vpn_bridge_group_bridge_domain_access_vfi.go
@@ -262,6 +262,19 @@ func (data L2VPNBridgeGroupBridgeDomainAccessVFI) toBodyXML(ctx context.Context,
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_l2vpn_bridge_group_bridge_domain_neighbor.go
+++ b/internal/provider/model_iosxr_l2vpn_bridge_group_bridge_domain_neighbor.go
@@ -993,6 +993,19 @@ func (data L2VPNBridgeGroupBridgeDomainNeighbor) toBodyXML(ctx context.Context, 
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_l2vpn_bridge_group_bridge_domain_vfi.go
+++ b/internal/provider/model_iosxr_l2vpn_bridge_group_bridge_domain_vfi.go
@@ -1479,6 +1479,19 @@ func (data L2VPNBridgeGroupBridgeDomainVFI) toBodyXML(ctx context.Context, state
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_l2vpn_pw_class.go
+++ b/internal/provider/model_iosxr_l2vpn_pw_class.go
@@ -820,6 +820,19 @@ func (data L2VPNPWClass) toBodyXML(ctx context.Context, stateArg ...*L2VPNPWClas
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_l2vpn_xconnect_group.go
+++ b/internal/provider/model_iosxr_l2vpn_xconnect_group.go
@@ -4368,6 +4368,19 @@ func (data L2VPNXconnectGroup) toBodyXML(ctx context.Context, stateArg ...*L2VPN
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_lacp.go
+++ b/internal/provider/model_iosxr_lacp.go
@@ -115,6 +115,19 @@ func (data LACP) toBodyXML(ctx context.Context, stateArg ...*LACP) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_large_community_set.go
+++ b/internal/provider/model_iosxr_large_community_set.go
@@ -149,7 +149,7 @@ func (data LargeCommunitySet) toBodyXML(ctx context.Context, stateArg ...*LargeC
 
 func (data *LargeCommunitySet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/large-community-set-as-text"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -200,7 +200,7 @@ func (data *LargeCommunitySetData) fromBody(ctx context.Context, res gjson.Resul
 
 func (data *LargeCommunitySet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/large-community-set-as-text"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -214,7 +214,7 @@ func (data *LargeCommunitySet) fromBodyXML(ctx context.Context, res xmldot.Resul
 
 func (data *LargeCommunitySetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/large-community-set-as-text"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_large_community_set.go
+++ b/internal/provider/model_iosxr_large_community_set.go
@@ -123,6 +123,19 @@ func (data LargeCommunitySet) toBodyXML(ctx context.Context, stateArg ...*LargeC
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_line_console.go
+++ b/internal/provider/model_iosxr_line_console.go
@@ -860,6 +860,19 @@ func (data LineConsole) toBodyXML(ctx context.Context, stateArg ...*LineConsole)
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_line_default.go
+++ b/internal/provider/model_iosxr_line_default.go
@@ -873,6 +873,19 @@ func (data LineDefault) toBodyXML(ctx context.Context, stateArg ...*LineDefault)
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_line_template.go
+++ b/internal/provider/model_iosxr_line_template.go
@@ -880,6 +880,19 @@ func (data LineTemplate) toBodyXML(ctx context.Context, stateArg ...*LineTemplat
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_linux_networking.go
+++ b/internal/provider/model_iosxr_linux_networking.go
@@ -788,6 +788,19 @@ func (data LinuxNetworking) toBodyXML(ctx context.Context, stateArg ...*LinuxNet
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_lldp.go
+++ b/internal/provider/model_iosxr_lldp.go
@@ -574,6 +574,19 @@ func (data LLDP) toBodyXML(ctx context.Context, stateArg ...*LLDP) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_logging.go
+++ b/internal/provider/model_iosxr_logging.go
@@ -1434,6 +1434,19 @@ func (data Logging) toBodyXML(ctx context.Context, stateArg ...*Logging) string 
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_logging_vrf.go
+++ b/internal/provider/model_iosxr_logging_vrf.go
@@ -442,6 +442,19 @@ func (data LoggingVRF) toBodyXML(ctx context.Context, stateArg ...*LoggingVRF) s
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_lpts_punt_police.go
+++ b/internal/provider/model_iosxr_lpts_punt_police.go
@@ -476,6 +476,19 @@ func (data LPTSPuntPolice) toBodyXML(ctx context.Context, stateArg ...*LPTSPuntP
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_mac_set.go
+++ b/internal/provider/model_iosxr_mac_set.go
@@ -149,7 +149,7 @@ func (data MacSet) toBodyXML(ctx context.Context, stateArg ...*MacSet) string {
 
 func (data *MacSet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/mac-set-as-text"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -200,7 +200,7 @@ func (data *MacSetData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *MacSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/mac-set-as-text"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -214,7 +214,7 @@ func (data *MacSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 
 func (data *MacSetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/mac-set-as-text"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_mac_set.go
+++ b/internal/provider/model_iosxr_mac_set.go
@@ -123,6 +123,19 @@ func (data MacSet) toBodyXML(ctx context.Context, stateArg ...*MacSet) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_macsec.go
+++ b/internal/provider/model_iosxr_macsec.go
@@ -150,6 +150,19 @@ func (data MACSec) toBodyXML(ctx context.Context, stateArg ...*MACSec) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_macsec_policy.go
+++ b/internal/provider/model_iosxr_macsec_policy.go
@@ -555,6 +555,19 @@ func (data MACSecPolicy) toBodyXML(ctx context.Context, stateArg ...*MACSecPolic
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_monitor_session.go
+++ b/internal/provider/model_iosxr_monitor_session.go
@@ -729,6 +729,19 @@ func (data MonitorSession) toBodyXML(ctx context.Context, stateArg ...*MonitorSe
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_mpls_ldp.go
+++ b/internal/provider/model_iosxr_mpls_ldp.go
@@ -1011,6 +1011,19 @@ func (data MPLSLDP) toBodyXML(ctx context.Context, stateArg ...*MPLSLDP) string 
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_mpls_ldp_address_family.go
+++ b/internal/provider/model_iosxr_mpls_ldp_address_family.go
@@ -865,6 +865,19 @@ func (data MPLSLDPAddressFamily) toBodyXML(ctx context.Context, stateArg ...*MPL
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_mpls_ldp_interface.go
+++ b/internal/provider/model_iosxr_mpls_ldp_interface.go
@@ -342,6 +342,19 @@ func (data MPLSLDPInterface) toBodyXML(ctx context.Context, stateArg ...*MPLSLDP
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_mpls_ldp_mldp.go
+++ b/internal/provider/model_iosxr_mpls_ldp_mldp.go
@@ -557,6 +557,19 @@ func (data MPLSLDPMLDP) toBodyXML(ctx context.Context, stateArg ...*MPLSLDPMLDP)
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_mpls_ldp_vrf.go
+++ b/internal/provider/model_iosxr_mpls_ldp_vrf.go
@@ -1201,6 +1201,19 @@ func (data MPLSLDPVRF) toBodyXML(ctx context.Context, stateArg ...*MPLSLDPVRF) s
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_mpls_oam.go
+++ b/internal/provider/model_iosxr_mpls_oam.go
@@ -315,6 +315,19 @@ func (data MPLSOAM) toBodyXML(ctx context.Context, stateArg ...*MPLSOAM) string 
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_mpls_traffic_eng.go
+++ b/internal/provider/model_iosxr_mpls_traffic_eng.go
@@ -110,6 +110,19 @@ func (data MPLSTrafficEng) toBodyXML(ctx context.Context, stateArg ...*MPLSTraff
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_netconf_agent_tty.go
+++ b/internal/provider/model_iosxr_netconf_agent_tty.go
@@ -157,6 +157,19 @@ func (data NetconfAgentTTY) toBodyXML(ctx context.Context, stateArg ...*NetconfA
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_netconf_yang_agent.go
+++ b/internal/provider/model_iosxr_netconf_yang_agent.go
@@ -239,6 +239,19 @@ func (data NetconfYangAgent) toBodyXML(ctx context.Context, stateArg ...*Netconf
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_ntp.go
+++ b/internal/provider/model_iosxr_ntp.go
@@ -2728,6 +2728,19 @@ func (data NTP) toBodyXML(ctx context.Context, stateArg ...*NTP) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_ospf_area_set.go
+++ b/internal/provider/model_iosxr_ospf_area_set.go
@@ -149,7 +149,7 @@ func (data OSPFAreaSet) toBodyXML(ctx context.Context, stateArg ...*OSPFAreaSet)
 
 func (data *OSPFAreaSet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rplospf-area-set"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -200,7 +200,7 @@ func (data *OSPFAreaSetData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *OSPFAreaSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rplospf-area-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -214,7 +214,7 @@ func (data *OSPFAreaSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 
 func (data *OSPFAreaSetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rplospf-area-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_ospf_area_set.go
+++ b/internal/provider/model_iosxr_ospf_area_set.go
@@ -123,6 +123,19 @@ func (data OSPFAreaSet) toBodyXML(ctx context.Context, stateArg ...*OSPFAreaSet)
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_pce.go
+++ b/internal/provider/model_iosxr_pce.go
@@ -8268,6 +8268,19 @@ func (data PCE) toBodyXML(ctx context.Context, stateArg ...*PCE) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_performance_measurement.go
+++ b/internal/provider/model_iosxr_performance_measurement.go
@@ -773,6 +773,19 @@ func (data PerformanceMeasurement) toBodyXML(ctx context.Context, stateArg ...*P
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_performance_measurement_delay_profile.go
+++ b/internal/provider/model_iosxr_performance_measurement_delay_profile.go
@@ -1969,6 +1969,19 @@ func (data PerformanceMeasurementDelayProfile) toBodyXML(ctx context.Context, st
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_performance_measurement_endpoint_ipv4.go
+++ b/internal/provider/model_iosxr_performance_measurement_endpoint_ipv4.go
@@ -408,6 +408,19 @@ func (data PerformanceMeasurementEndpointIPv4) toBodyXML(ctx context.Context, st
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_performance_measurement_endpoint_ipv6.go
+++ b/internal/provider/model_iosxr_performance_measurement_endpoint_ipv6.go
@@ -408,6 +408,19 @@ func (data PerformanceMeasurementEndpointIPv6) toBodyXML(ctx context.Context, st
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_performance_measurement_interface.go
+++ b/internal/provider/model_iosxr_performance_measurement_interface.go
@@ -352,6 +352,19 @@ func (data PerformanceMeasurementInterface) toBodyXML(ctx context.Context, state
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_performance_measurement_liveness_profile.go
+++ b/internal/provider/model_iosxr_performance_measurement_liveness_profile.go
@@ -723,6 +723,19 @@ func (data PerformanceMeasurementLivenessProfile) toBodyXML(ctx context.Context,
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_policy_global_set.go
+++ b/internal/provider/model_iosxr_policy_global_set.go
@@ -116,6 +116,19 @@ func (data PolicyGlobalSet) toBodyXML(ctx context.Context, stateArg ...*PolicyGl
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_policy_global_set.go
+++ b/internal/provider/model_iosxr_policy_global_set.go
@@ -142,7 +142,7 @@ func (data PolicyGlobalSet) toBodyXML(ctx context.Context, stateArg ...*PolicyGl
 
 func (data *PolicyGlobalSet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/policy-global-set"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -193,7 +193,7 @@ func (data *PolicyGlobalSetData) fromBody(ctx context.Context, res gjson.Result)
 
 func (data *PolicyGlobalSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/policy-global-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -207,7 +207,7 @@ func (data *PolicyGlobalSet) fromBodyXML(ctx context.Context, res xmldot.Result)
 
 func (data *PolicyGlobalSetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/policy-global-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_policy_map_pbr.go
+++ b/internal/provider/model_iosxr_policy_map_pbr.go
@@ -483,6 +483,19 @@ func (data PolicyMapPBR) toBodyXML(ctx context.Context, stateArg ...*PolicyMapPB
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_policy_map_qos.go
+++ b/internal/provider/model_iosxr_policy_map_qos.go
@@ -1056,6 +1056,19 @@ func (data PolicyMapQoS) toBodyXML(ctx context.Context, stateArg ...*PolicyMapQo
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_prefix_set.go
+++ b/internal/provider/model_iosxr_prefix_set.go
@@ -151,7 +151,7 @@ func (data *PrefixSet) updateFromBody(ctx context.Context, res gjson.Result) {
 
 func (data *PrefixSet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-prefix-set"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -202,7 +202,7 @@ func (data *PrefixSetData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *PrefixSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-prefix-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -216,7 +216,7 @@ func (data *PrefixSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 
 func (data *PrefixSetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-prefix-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_prefix_set.go
+++ b/internal/provider/model_iosxr_prefix_set.go
@@ -112,6 +112,19 @@ func (data PrefixSet) toBodyXML(ctx context.Context, stateArg ...*PrefixSet) str
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_ptp.go
+++ b/internal/provider/model_iosxr_ptp.go
@@ -1272,6 +1272,19 @@ func (data PTP) toBodyXML(ctx context.Context, stateArg ...*PTP) string {
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_ptp_profile.go
+++ b/internal/provider/model_iosxr_ptp_profile.go
@@ -2077,6 +2077,19 @@ func (data PTPProfile) toBodyXML(ctx context.Context, stateArg ...*PTPProfile) s
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_radius_server.go
+++ b/internal/provider/model_iosxr_radius_server.go
@@ -816,6 +816,19 @@ func (data RadiusServer) toBodyXML(ctx context.Context, stateArg ...*RadiusServe
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_radius_source_interface.go
+++ b/internal/provider/model_iosxr_radius_source_interface.go
@@ -123,6 +123,19 @@ func (data RadiusSourceInterface) toBodyXML(ctx context.Context, stateArg ...*Ra
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_rd_set.go
+++ b/internal/provider/model_iosxr_rd_set.go
@@ -112,6 +112,19 @@ func (data RDSet) toBodyXML(ctx context.Context, stateArg ...*RDSet) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_rd_set.go
+++ b/internal/provider/model_iosxr_rd_set.go
@@ -151,7 +151,7 @@ func (data *RDSet) updateFromBody(ctx context.Context, res gjson.Result) {
 
 func (data *RDSet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rplrd-set"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -202,7 +202,7 @@ func (data *RDSetData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *RDSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rplrd-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -216,7 +216,7 @@ func (data *RDSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 
 func (data *RDSetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rplrd-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_route_policy.go
+++ b/internal/provider/model_iosxr_route_policy.go
@@ -151,7 +151,7 @@ func (data *RoutePolicy) updateFromBody(ctx context.Context, res gjson.Result) {
 
 func (data *RoutePolicy) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-route-policy"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -202,7 +202,7 @@ func (data *RoutePolicyData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *RoutePolicy) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-route-policy"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -216,7 +216,7 @@ func (data *RoutePolicy) fromBodyXML(ctx context.Context, res xmldot.Result) {
 
 func (data *RoutePolicyData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-route-policy"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_route_policy.go
+++ b/internal/provider/model_iosxr_route_policy.go
@@ -112,6 +112,19 @@ func (data RoutePolicy) toBodyXML(ctx context.Context, stateArg ...*RoutePolicy)
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_bgp.go
+++ b/internal/provider/model_iosxr_router_bgp.go
@@ -9900,6 +9900,19 @@ func (data RouterBGP) toBodyXML(ctx context.Context, stateArg ...*RouterBGP) str
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_bgp_address_family.go
+++ b/internal/provider/model_iosxr_router_bgp_address_family.go
@@ -9535,6 +9535,19 @@ func (data RouterBGPAddressFamily) toBodyXML(ctx context.Context, stateArg ...*R
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_bgp_af_group.go
+++ b/internal/provider/model_iosxr_router_bgp_af_group.go
@@ -3876,6 +3876,19 @@ func (data RouterBGPAFGroup) toBodyXML(ctx context.Context, stateArg ...*RouterB
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_bgp_neighbor_address_family.go
+++ b/internal/provider/model_iosxr_router_bgp_neighbor_address_family.go
@@ -3876,6 +3876,19 @@ func (data RouterBGPNeighborAddressFamily) toBodyXML(ctx context.Context, stateA
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_bgp_neighbor_group.go
+++ b/internal/provider/model_iosxr_router_bgp_neighbor_group.go
@@ -7472,6 +7472,19 @@ func (data RouterBGPNeighborGroup) toBodyXML(ctx context.Context, stateArg ...*R
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_bgp_session_group.go
+++ b/internal/provider/model_iosxr_router_bgp_session_group.go
@@ -4067,6 +4067,19 @@ func (data RouterBGPSessionGroup) toBodyXML(ctx context.Context, stateArg ...*Ro
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_bgp_vrf.go
+++ b/internal/provider/model_iosxr_router_bgp_vrf.go
@@ -6789,6 +6789,19 @@ func (data RouterBGPVRF) toBodyXML(ctx context.Context, stateArg ...*RouterBGPVR
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_bgp_vrf_address_family.go
+++ b/internal/provider/model_iosxr_router_bgp_vrf_address_family.go
@@ -7915,6 +7915,19 @@ func (data RouterBGPVRFAddressFamily) toBodyXML(ctx context.Context, stateArg ..
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_bgp_vrf_neighbor_address_family.go
+++ b/internal/provider/model_iosxr_router_bgp_vrf_neighbor_address_family.go
@@ -3924,6 +3924,19 @@ func (data RouterBGPVRFNeighborAddressFamily) toBodyXML(ctx context.Context, sta
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_hsrp_interface.go
+++ b/internal/provider/model_iosxr_router_hsrp_interface.go
@@ -170,6 +170,19 @@ func (data RouterHSRPInterface) toBodyXML(ctx context.Context, stateArg ...*Rout
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_hsrp_interface_ipv4_group_v1.go
+++ b/internal/provider/model_iosxr_router_hsrp_interface_ipv4_group_v1.go
@@ -455,6 +455,19 @@ func (data RouterHSRPInterfaceIPv4GroupV1) toBodyXML(ctx context.Context, stateA
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_hsrp_interface_ipv4_group_v2.go
+++ b/internal/provider/model_iosxr_router_hsrp_interface_ipv4_group_v2.go
@@ -455,6 +455,19 @@ func (data RouterHSRPInterfaceIPv4GroupV2) toBodyXML(ctx context.Context, stateA
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_hsrp_interface_ipv6_group_v2.go
+++ b/internal/provider/model_iosxr_router_hsrp_interface_ipv6_group_v2.go
@@ -478,6 +478,19 @@ func (data RouterHSRPInterfaceIPv6GroupV2) toBodyXML(ctx context.Context, stateA
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_igmp.go
+++ b/internal/provider/model_iosxr_router_igmp.go
@@ -495,6 +495,19 @@ func (data RouterIGMP) toBodyXML(ctx context.Context, stateArg ...*RouterIGMP) s
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_igmp_interface.go
+++ b/internal/provider/model_iosxr_router_igmp_interface.go
@@ -848,6 +848,19 @@ func (data RouterIGMPInterface) toBodyXML(ctx context.Context, stateArg ...*Rout
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_igmp_vrf.go
+++ b/internal/provider/model_iosxr_router_igmp_vrf.go
@@ -476,6 +476,19 @@ func (data RouterIGMPVRF) toBodyXML(ctx context.Context, stateArg ...*RouterIGMP
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_igmp_vrf_interface.go
+++ b/internal/provider/model_iosxr_router_igmp_vrf_interface.go
@@ -850,6 +850,19 @@ func (data RouterIGMPVRFInterface) toBodyXML(ctx context.Context, stateArg ...*R
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_isis.go
+++ b/internal/provider/model_iosxr_router_isis.go
@@ -7370,6 +7370,19 @@ func (data RouterISIS) toBodyXML(ctx context.Context, stateArg ...*RouterISIS) s
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_isis_address_family.go
+++ b/internal/provider/model_iosxr_router_isis_address_family.go
@@ -9681,6 +9681,19 @@ func (data RouterISISAddressFamily) toBodyXML(ctx context.Context, stateArg ...*
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_isis_interface.go
+++ b/internal/provider/model_iosxr_router_isis_interface.go
@@ -2706,6 +2706,19 @@ func (data RouterISISInterface) toBodyXML(ctx context.Context, stateArg ...*Rout
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_isis_interface_address_family.go
+++ b/internal/provider/model_iosxr_router_isis_interface_address_family.go
@@ -5282,6 +5282,19 @@ func (data RouterISISInterfaceAddressFamily) toBodyXML(ctx context.Context, stat
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_mld.go
+++ b/internal/provider/model_iosxr_router_mld.go
@@ -446,6 +446,19 @@ func (data RouterMLD) toBodyXML(ctx context.Context, stateArg ...*RouterMLD) str
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_mld_interface.go
+++ b/internal/provider/model_iosxr_router_mld_interface.go
@@ -848,6 +848,19 @@ func (data RouterMLDInterface) toBodyXML(ctx context.Context, stateArg ...*Route
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_mld_vrf.go
+++ b/internal/provider/model_iosxr_router_mld_vrf.go
@@ -440,6 +440,19 @@ func (data RouterMLDVRF) toBodyXML(ctx context.Context, stateArg ...*RouterMLDVR
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_mld_vrf_interface.go
+++ b/internal/provider/model_iosxr_router_mld_vrf_interface.go
@@ -850,6 +850,19 @@ func (data RouterMLDVRFInterface) toBodyXML(ctx context.Context, stateArg ...*Ro
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_ospf.go
+++ b/internal/provider/model_iosxr_router_ospf.go
@@ -12935,6 +12935,19 @@ func (data RouterOSPF) toBodyXML(ctx context.Context, stateArg ...*RouterOSPF) s
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_ospf_area.go
+++ b/internal/provider/model_iosxr_router_ospf_area.go
@@ -8439,6 +8439,19 @@ func (data RouterOSPFArea) toBodyXML(ctx context.Context, stateArg ...*RouterOSP
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_ospf_area_interface.go
+++ b/internal/provider/model_iosxr_router_ospf_area_interface.go
@@ -5671,6 +5671,19 @@ func (data RouterOSPFAreaInterface) toBodyXML(ctx context.Context, stateArg ...*
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_ospf_vrf.go
+++ b/internal/provider/model_iosxr_router_ospf_vrf.go
@@ -10425,6 +10425,19 @@ func (data RouterOSPFVRF) toBodyXML(ctx context.Context, stateArg ...*RouterOSPF
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_ospf_vrf_area.go
+++ b/internal/provider/model_iosxr_router_ospf_vrf_area.go
@@ -5714,6 +5714,19 @@ func (data RouterOSPFVRFArea) toBodyXML(ctx context.Context, stateArg ...*Router
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_ospf_vrf_area_interface.go
+++ b/internal/provider/model_iosxr_router_ospf_vrf_area_interface.go
@@ -5256,6 +5256,19 @@ func (data RouterOSPFVRFAreaInterface) toBodyXML(ctx context.Context, stateArg .
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_pim_ipv4.go
+++ b/internal/provider/model_iosxr_router_pim_ipv4.go
@@ -3352,6 +3352,19 @@ func (data RouterPIMIPv4) toBodyXML(ctx context.Context, stateArg ...*RouterPIMI
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_pim_ipv6.go
+++ b/internal/provider/model_iosxr_router_pim_ipv6.go
@@ -1940,6 +1940,19 @@ func (data RouterPIMIPv6) toBodyXML(ctx context.Context, stateArg ...*RouterPIMI
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_pim_vrf_ipv4.go
+++ b/internal/provider/model_iosxr_router_pim_vrf_ipv4.go
@@ -2057,6 +2057,19 @@ func (data RouterPIMVRFIPv4) toBodyXML(ctx context.Context, stateArg ...*RouterP
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_pim_vrf_ipv6.go
+++ b/internal/provider/model_iosxr_router_pim_vrf_ipv6.go
@@ -1775,6 +1775,19 @@ func (data RouterPIMVRFIPv6) toBodyXML(ctx context.Context, stateArg ...*RouterP
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_static_ipv4_multicast.go
+++ b/internal/provider/model_iosxr_router_static_ipv4_multicast.go
@@ -1335,6 +1335,19 @@ func (data RouterStaticIPv4Multicast) toBodyXML(ctx context.Context, stateArg ..
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_static_ipv4_unicast.go
+++ b/internal/provider/model_iosxr_router_static_ipv4_unicast.go
@@ -1335,6 +1335,19 @@ func (data RouterStaticIPv4Unicast) toBodyXML(ctx context.Context, stateArg ...*
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_static_ipv6_multicast.go
+++ b/internal/provider/model_iosxr_router_static_ipv6_multicast.go
@@ -1335,6 +1335,19 @@ func (data RouterStaticIPv6Multicast) toBodyXML(ctx context.Context, stateArg ..
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_static_ipv6_unicast.go
+++ b/internal/provider/model_iosxr_router_static_ipv6_unicast.go
@@ -1335,6 +1335,19 @@ func (data RouterStaticIPv6Unicast) toBodyXML(ctx context.Context, stateArg ...*
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_static_vrf_ipv4_multicast.go
+++ b/internal/provider/model_iosxr_router_static_vrf_ipv4_multicast.go
@@ -1337,6 +1337,19 @@ func (data RouterStaticVRFIPv4Multicast) toBodyXML(ctx context.Context, stateArg
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_static_vrf_ipv4_unicast.go
+++ b/internal/provider/model_iosxr_router_static_vrf_ipv4_unicast.go
@@ -1337,6 +1337,19 @@ func (data RouterStaticVRFIPv4Unicast) toBodyXML(ctx context.Context, stateArg .
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_static_vrf_ipv6_multicast.go
+++ b/internal/provider/model_iosxr_router_static_vrf_ipv6_multicast.go
@@ -1337,6 +1337,19 @@ func (data RouterStaticVRFIPv6Multicast) toBodyXML(ctx context.Context, stateArg
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_static_vrf_ipv6_unicast.go
+++ b/internal/provider/model_iosxr_router_static_vrf_ipv6_unicast.go
@@ -1337,6 +1337,19 @@ func (data RouterStaticVRFIPv6Unicast) toBodyXML(ctx context.Context, stateArg .
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_vrrp_interface.go
+++ b/internal/provider/model_iosxr_router_vrrp_interface.go
@@ -146,6 +146,19 @@ func (data RouterVRRPInterface) toBodyXML(ctx context.Context, stateArg ...*Rout
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_vrrp_interface_ipv4.go
+++ b/internal/provider/model_iosxr_router_vrrp_interface_ipv4.go
@@ -475,6 +475,19 @@ func (data RouterVRRPInterfaceIPv4) toBodyXML(ctx context.Context, stateArg ...*
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_router_vrrp_interface_ipv6.go
+++ b/internal/provider/model_iosxr_router_vrrp_interface_ipv6.go
@@ -485,6 +485,19 @@ func (data RouterVRRPInterfaceIPv6) toBodyXML(ctx context.Context, stateArg ...*
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_rsvp.go
+++ b/internal/provider/model_iosxr_rsvp.go
@@ -795,6 +795,19 @@ func (data RSVP) toBodyXML(ctx context.Context, stateArg ...*RSVP) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_rsvp_interface.go
+++ b/internal/provider/model_iosxr_rsvp_interface.go
@@ -956,6 +956,19 @@ func (data RSVPInterface) toBodyXML(ctx context.Context, stateArg ...*RSVPInterf
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_segment_routing.go
+++ b/internal/provider/model_iosxr_segment_routing.go
@@ -181,6 +181,19 @@ func (data SegmentRouting) toBodyXML(ctx context.Context, stateArg ...*SegmentRo
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_segment_routing_mapping_server.go
+++ b/internal/provider/model_iosxr_segment_routing_mapping_server.go
@@ -260,6 +260,19 @@ func (data SegmentRoutingMappingServer) toBodyXML(ctx context.Context, stateArg 
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_segment_routing_te.go
+++ b/internal/provider/model_iosxr_segment_routing_te.go
@@ -4527,6 +4527,19 @@ func (data SegmentRoutingTE) toBodyXML(ctx context.Context, stateArg ...*Segment
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_segment_routing_te_on_demand_color.go
+++ b/internal/provider/model_iosxr_segment_routing_te_on_demand_color.go
@@ -1992,6 +1992,19 @@ func (data SegmentRoutingTEOnDemandColor) toBodyXML(ctx context.Context, stateAr
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_segment_routing_te_policy.go
+++ b/internal/provider/model_iosxr_segment_routing_te_policy.go
@@ -3213,6 +3213,19 @@ func (data SegmentRoutingTEPolicy) toBodyXML(ctx context.Context, stateArg ...*S
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_segment_routing_v6.go
+++ b/internal/provider/model_iosxr_segment_routing_v6.go
@@ -483,6 +483,19 @@ func (data SegmentRoutingV6) toBodyXML(ctx context.Context, stateArg ...*Segment
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_service_timestamps.go
+++ b/internal/provider/model_iosxr_service_timestamps.go
@@ -265,6 +265,19 @@ func (data ServiceTimestamps) toBodyXML(ctx context.Context, stateArg ...*Servic
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_snmp_server.go
+++ b/internal/provider/model_iosxr_snmp_server.go
@@ -4485,6 +4485,19 @@ func (data SNMPServer) toBodyXML(ctx context.Context, stateArg ...*SNMPServer) s
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_snmp_server_mib.go
+++ b/internal/provider/model_iosxr_snmp_server_mib.go
@@ -767,6 +767,19 @@ func (data SNMPServerMIB) toBodyXML(ctx context.Context, stateArg ...*SNMPServer
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_snmp_server_vrf.go
+++ b/internal/provider/model_iosxr_snmp_server_vrf.go
@@ -1508,6 +1508,19 @@ func (data SNMPServerVRF) toBodyXML(ctx context.Context, stateArg ...*SNMPServer
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_srlg.go
+++ b/internal/provider/model_iosxr_srlg.go
@@ -688,6 +688,19 @@ func (data SRLG) toBodyXML(ctx context.Context, stateArg ...*SRLG) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_ssh.go
+++ b/internal/provider/model_iosxr_ssh.go
@@ -1229,6 +1229,19 @@ func (data SSH) toBodyXML(ctx context.Context, stateArg ...*SSH) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_tacacs_server.go
+++ b/internal/provider/model_iosxr_tacacs_server.go
@@ -321,6 +321,19 @@ func (data TACACSServer) toBodyXML(ctx context.Context, stateArg ...*TACACSServe
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_tacacs_source_interface.go
+++ b/internal/provider/model_iosxr_tacacs_source_interface.go
@@ -180,6 +180,19 @@ func (data TACACSSourceInterface) toBodyXML(ctx context.Context, stateArg ...*TA
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_tag_set.go
+++ b/internal/provider/model_iosxr_tag_set.go
@@ -123,6 +123,19 @@ func (data TagSet) toBodyXML(ctx context.Context, stateArg ...*TagSet) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_tag_set.go
+++ b/internal/provider/model_iosxr_tag_set.go
@@ -149,7 +149,7 @@ func (data TagSet) toBodyXML(ctx context.Context, stateArg ...*TagSet) string {
 
 func (data *TagSet) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-tag-set"); value.Exists() && !data.Rpl.IsNull() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -200,7 +200,7 @@ func (data *TagSetData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *TagSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-tag-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
@@ -214,7 +214,7 @@ func (data *TagSet) fromBodyXML(ctx context.Context, res xmldot.Result) {
 
 func (data *TagSetData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/rpl-tag-set"); value.Exists() {
-		// Normalize RPL value to ensure it ends with newline (matches gNMI behavior)
+		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := value.String()
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"

--- a/internal/provider/model_iosxr_tcp.go
+++ b/internal/provider/model_iosxr_tcp.go
@@ -424,6 +424,19 @@ func (data TCP) toBodyXML(ctx context.Context, stateArg ...*TCP) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_telemetry_model_driven.go
+++ b/internal/provider/model_iosxr_telemetry_model_driven.go
@@ -1158,6 +1158,19 @@ func (data TelemetryModelDriven) toBodyXML(ctx context.Context, stateArg ...*Tel
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_telnet.go
+++ b/internal/provider/model_iosxr_telnet.go
@@ -193,6 +193,19 @@ func (data Telnet) toBodyXML(ctx context.Context, stateArg ...*Telnet) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_tftp_client.go
+++ b/internal/provider/model_iosxr_tftp_client.go
@@ -203,6 +203,19 @@ func (data TFTPClient) toBodyXML(ctx context.Context, stateArg ...*TFTPClient) s
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_tftp_server.go
+++ b/internal/provider/model_iosxr_tftp_server.go
@@ -251,6 +251,19 @@ func (data TFTPServer) toBodyXML(ctx context.Context, stateArg ...*TFTPServer) s
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_tpa.go
+++ b/internal/provider/model_iosxr_tpa.go
@@ -552,6 +552,19 @@ func (data TPA) toBodyXML(ctx context.Context, stateArg ...*TPA) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_track.go
+++ b/internal/provider/model_iosxr_track.go
@@ -1269,6 +1269,19 @@ func (data Track) toBodyXML(ctx context.Context, stateArg ...*Track) string {
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_vrf.go
+++ b/internal/provider/model_iosxr_vrf.go
@@ -3355,6 +3355,19 @@ func (data VRF) toBodyXML(ctx context.Context, stateArg ...*VRF) string {
 		}
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_vty_pool.go
+++ b/internal/provider/model_iosxr_vty_pool.go
@@ -270,6 +270,19 @@ func (data VTYPool) toBodyXML(ctx context.Context, stateArg ...*VTYPool) string 
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()

--- a/internal/provider/model_iosxr_xml_agent.go
+++ b/internal/provider/model_iosxr_xml_agent.go
@@ -598,6 +598,19 @@ func (data XMLAgent) toBodyXML(ctx context.Context, stateArg ...*XMLAgent) strin
 		return ""
 	}
 	bodyString = helpers.AddNamespaceToRootElement(bodyString, data.getXPath())
+	// On Create, seed the keyed base node when no leaves were emitted so a
+	// keys-only entry (e.g. address-family ipv4 unicast) isn't sent as an empty
+	// body, which EditConfig skips — creating drift. Uses default merge
+	// (RFC 6241 §7.2); getXPath()'s key gives a valid minimal list entry
+	// (RFC 7950 §7.8.2). Create-only (state == nil) leaves Update untouched.
+	if bodyString == "" && state == nil {
+		seededBody, seedErr := helpers.BodyToNestedXML(helpers.SetFromXPath(netconf.Body{}, data.getXPath(), ""))
+		if seedErr != nil {
+			tflog.Error(ctx, fmt.Sprintf("Error seeding keys-only base node: %s", seedErr))
+		} else {
+			bodyString = helpers.AddNamespaceToRootElement(seededBody, data.getXPath())
+		}
+	}
 	// Append delete XML for empty bool leafs (false values that need explicit removal)
 	for _, deletePath := range data.getEmptyLeafsDelete(ctx, state) {
 		bodyString += helpers.RemoveFromXPath(netconf.Body{}, deletePath).Res()


### PR DESCRIPTION
## Summary

Two related NETCONF idempotency fixes that eliminate plan drift after apply.

- **Keys-only container create** (`gen/templates/model.go` + regenerated models): When a resource has only key attributes (e.g. `address-family ipv4 unicast`, `bundle-ether subinterface`, bare logical interfaces), `toBodyXML` emits an empty body. NETCONF `EditConfig` silently skips empty payloads, leaving the list entry uncreated and causing plan drift on every subsequent apply. On Create (`state == nil`), the keyed base node is now seeded via `SetFromXPath`/`BodyToNestedXML` so `EditConfig` receives a valid minimal list entry per RFC 7950 §7.8.2 and RFC 6241 §7.2. The Update path (`state != nil`) is unaffected.

- **Banner `line` trailing newline** (`gen/templates/model.go` + `model_iosxr_banner.go`): NETCONF banner reads lose the trailing newline because `xmldot`'s `extractTextContent()` calls `strings.TrimSpace()`. gNMI is unaffected (gjson preserves the newline in JSON). The existing RPL newline-normalization condition in `updateFromBodyXML` is extended to also cover `Banner.line`, re-adding the newline after `xmldot` strips it so NETCONF reads match gNMI and plan drift is eliminated.

## Test plan

- [x] `go build ./...` passes
- [x] `terraform plan` after `terraform apply` shows 0 changes for banner resources (NETCONF)
- [x] `terraform plan` after `terraform apply` shows 0 changes for keys-only container resources (NETCONF)
- [x] gNMI transport unaffected — banner and interface drift fixes are isolated to the NETCONF read path (`updateFromBodyXML`/`fromBodyXML`)