### PR TITLE
fix(banner): correct NETCONF read to return device value without trailing newline

### DIFF
--- a/gen/templates/model.go
+++ b/gen/templates/model.go
@@ -2403,13 +2403,16 @@ func (data *{{camelCase .Name}}) updateFromBodyXML(ctx context.Context, res xmld
 	{{- end}}
 	{{- else if eq .Type "String"}}
 	if value := helpers.GetFromXPath(res, "data/" + data.getXPath() + "/{{.XPath}}"); value.Exists() && !data.{{toGoName .TfName}}.IsNull() {
-		{{- if or (eq .TfName "rpl") (hasPrefix .YangName "rpl") (and (eq $.Name "Banner") (eq .TfName "line"))}}
+		{{- if or (eq .TfName "rpl") (hasPrefix .YangName "rpl")}}
 		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := {{if .ReadRaw}}value.Raw{{else}}value.String(){{end}}
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
 		}
 		data.{{toGoName .TfName}} = types.StringValue(rplValue)
+		{{- else if and (eq $.Name "Banner") (eq .TfName "line")}}
+		// Device normalizes banner content by stripping trailing newlines; read back exactly what the device returns.
+		data.{{toGoName .TfName}} = types.StringValue(value.String())
 		{{- else}}
 		data.{{toGoName .TfName}} = types.StringValue({{if .ReadRaw}}value.Raw{{else}}value.String(){{end}})
 		{{- end}}
@@ -2673,13 +2676,16 @@ func (data *{{camelCase .Name}}) fromBodyXML(ctx context.Context, res xmldot.Res
 	}
 	{{- else if eq .Type "String"}}
 	if value := helpers.GetFromXPath(res, "data/" + data.getXPath() + "/{{.XPath}}"); value.Exists() {
-		{{- if or (eq .TfName "rpl") (hasPrefix .YangName "rpl") (and (eq $.Name "Banner") (eq .TfName "line"))}}
+		{{- if or (eq .TfName "rpl") (hasPrefix .YangName "rpl")}}
 		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := {{if .ReadRaw}}value.Raw{{else}}value.String(){{end}}
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
 		}
 		data.{{toGoName .TfName}} = types.StringValue(rplValue)
+		{{- else if and (eq $.Name "Banner") (eq .TfName "line")}}
+		// Device normalizes banner content by stripping trailing newlines; read back exactly what the device returns.
+		data.{{toGoName .TfName}} = types.StringValue(value.String())
 		{{- else}}
 		data.{{toGoName .TfName}} = types.StringValue({{if .ReadRaw}}value.Raw{{else}}value.String(){{end}})
 		{{- end}}
@@ -2971,13 +2977,16 @@ func (data *{{camelCase .Name}}Data) fromBodyXML(ctx context.Context, res xmldot
 	}
 	{{- else if eq .Type "String"}}
 	if value := helpers.GetFromXPath(res, "data/" + data.getXPath() + "/{{.XPath}}"); value.Exists() {
-		{{- if or (eq .TfName "rpl") (hasPrefix .YangName "rpl") (and (eq $.Name "Banner") (eq .TfName "line"))}}
+		{{- if or (eq .TfName "rpl") (hasPrefix .YangName "rpl")}}
 		// Normalize value to ensure it ends with newline (matches gNMI behavior)
 		rplValue := {{if .ReadRaw}}value.Raw{{else}}value.String(){{end}}
 		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
 			rplValue = rplValue + "\n"
 		}
 		data.{{toGoName .TfName}} = types.StringValue(rplValue)
+		{{- else if and (eq $.Name "Banner") (eq .TfName "line")}}
+		// Device normalizes banner content by stripping trailing newlines; read back exactly what the device returns.
+		data.{{toGoName .TfName}} = types.StringValue(value.String())
 		{{- else}}
 		data.{{toGoName .TfName}} = types.StringValue({{if .ReadRaw}}value.Raw{{else}}value.String(){{end}})
 		{{- end}}

--- a/internal/provider/model_iosxr_banner.go
+++ b/internal/provider/model_iosxr_banner.go
@@ -151,12 +151,8 @@ func (data *Banner) updateFromBody(ctx context.Context, res gjson.Result) {
 
 func (data *Banner) updateFromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/line"); value.Exists() && !data.Line.IsNull() {
-		// Normalize value to ensure it ends with newline (matches gNMI behavior)
-		rplValue := value.String()
-		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
-			rplValue = rplValue + "\n"
-		}
-		data.Line = types.StringValue(rplValue)
+		// Device normalizes banner content by stripping trailing newlines; read back exactly what the device returns.
+		data.Line = types.StringValue(value.String())
 	} else if data.Line.IsNull() {
 		data.Line = types.StringNull()
 	}
@@ -205,12 +201,8 @@ func (data *BannerData) fromBody(ctx context.Context, res gjson.Result) {
 
 func (data *Banner) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/line"); value.Exists() {
-		// Normalize value to ensure it ends with newline (matches gNMI behavior)
-		rplValue := value.String()
-		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
-			rplValue = rplValue + "\n"
-		}
-		data.Line = types.StringValue(rplValue)
+		// Device normalizes banner content by stripping trailing newlines; read back exactly what the device returns.
+		data.Line = types.StringValue(value.String())
 	}
 }
 
@@ -220,12 +212,8 @@ func (data *Banner) fromBodyXML(ctx context.Context, res xmldot.Result) {
 
 func (data *BannerData) fromBodyXML(ctx context.Context, res xmldot.Result) {
 	if value := helpers.GetFromXPath(res, "data/"+data.getXPath()+"/line"); value.Exists() {
-		// Normalize value to ensure it ends with newline (matches gNMI behavior)
-		rplValue := value.String()
-		if rplValue != "" && !strings.HasSuffix(rplValue, "\n") {
-			rplValue = rplValue + "\n"
-		}
-		data.Line = types.StringValue(rplValue)
+		// Device normalizes banner content by stripping trailing newlines; read back exactly what the device returns.
+		data.Line = types.StringValue(value.String())
 	}
 }
 


### PR DESCRIPTION
## Overview

Fixes a regression introduced by #358 where the banner `line` attribute was grouped with RPL attributes in the NETCONF read path, causing a trailing `\n` to be unconditionally appended to the value read back from the device. The IOS-XR device always strips trailing newlines from banner content, so NETCONF reads were returning `"content\n"` while the device stored `"content"`, causing the datasource acceptance test to fail and creating potential config drift.

## Changes

### Modified

- `gen/templates/model.go` — separated `iosxr_banner.line` from the RPL newline-normalization block in all three XML read functions (`updateFromBodyXML`, `fromBodyXML`, `fromBodyDataXML`); banner line now returns `value.String()` directly, which is what the device actually stores

## Testing

- `TestAccDataSourceIosxrBanner` and `TestAccIosxrBanner` acceptance tests pass over NETCONF (port 830)
- Verified plan/apply/plan produces no drift for all six banner types (`login`, `motd`, `exec`, `incoming`, `prompt-timeout`, `slip-ppp`) with all supported delimiter variants (`"`, `*`, `^C`, `\n`, `\`)
- Platform: XRv9K

## Checklist

- [x] `go generate` run after template changes
- [x] Acceptance tests pass
- [x] No drift on plan/apply/plan cycle
