### PR TITLE
test(helpers): expand test coverage for netconf, gnmi, and xpath utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.2
+## Unreleased
 
 - Add `contexts`, `context_mappings` lists to `iosxr_snmp_server` resource and data source
 - Fix: Make `auto_cost_reference_bandwidth` optional in `router_isis` resource and data source

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,7 +7,7 @@ description: |-
 
 # Changelog
 
-## 0.7.2
+## Unreleased
 
 - Add `contexts`, `context_mappings` lists to `iosxr_snmp_server` resource and data source
 - Fix: Make `auto_cost_reference_bandwidth` optional in `router_isis` resource and data source

--- a/internal/provider/helpers/gnmi_test.go
+++ b/internal/provider/helpers/gnmi_test.go
@@ -23,6 +23,9 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	ggnmi "github.com/netascode/go-gnmi"
+	gnmiproto "github.com/openconfig/gnmi/proto/gnmi"
 )
 
 // TestCloseGnmiConnection tests the CloseGnmiConnection function
@@ -59,25 +62,19 @@ func TestAcquireGnmiLock(t *testing.T) {
 		expectLock      bool
 	}{
 		{
-			name:            "no reuse - should lock",
+			name:            "no reuse locks regardless of operation type",
 			reuseConnection: false,
 			isWrite:         false,
 			expectLock:      true,
 		},
 		{
-			name:            "no reuse - write operation - should lock",
-			reuseConnection: false,
-			isWrite:         true,
-			expectLock:      true,
-		},
-		{
-			name:            "reuse - write operation - should lock",
+			name:            "reuse write locks",
 			reuseConnection: true,
 			isWrite:         true,
 			expectLock:      true,
 		},
 		{
-			name:            "reuse - read operation - should NOT lock",
+			name:            "reuse read does not lock",
 			reuseConnection: true,
 			isWrite:         false,
 			expectLock:      false,
@@ -93,12 +90,31 @@ func TestAcquireGnmiLock(t *testing.T) {
 				t.Errorf("AcquireGnmiLock() = %v, expected %v", acquired, tt.expectLock)
 			}
 
-			// If lock was acquired, unlock it
 			if acquired {
 				mutex.Unlock()
 			}
 		})
 	}
+
+	t.Run("no reuse blocks concurrent caller", func(t *testing.T) {
+		var mutex sync.Mutex
+		acquired := AcquireGnmiLock(&mutex, false, false)
+		if !acquired {
+			t.Fatal("first AcquireGnmiLock() should have acquired the lock")
+		}
+
+		done := make(chan bool, 1)
+		go func() {
+			done <- !mutex.TryLock()
+		}()
+		blocked := <-done
+
+		mutex.Unlock()
+
+		if !blocked {
+			t.Error("second caller should have been blocked while first held the lock")
+		}
+	})
 }
 
 // TestIsGnmiConnectionError tests the IsGnmiConnectionError function
@@ -149,7 +165,7 @@ func TestIsGnmiConnectionError(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "uppercase - Connection is Closing",
+			name:     "uppercase connection is closing",
 			err:      errors.New("Connection is Closing"),
 			expected: true,
 		},
@@ -175,17 +191,73 @@ func TestIsGnmiConnectionError(t *testing.T) {
 	}
 }
 
-// TestIsGnmiGetResponseEmpty tests the isGnmiGetResponseEmpty function
+// TestIsGnmiGetResponseEmpty tests all conditions in IsGnmiGetResponseEmpty.
 func TestIsGnmiGetResponseEmpty(t *testing.T) {
-	t.Run("nil response", func(t *testing.T) {
-		result := isGnmiGetResponseEmpty(nil)
-		if !result {
-			t.Error("isGnmiGetResponseEmpty(nil) should return true")
-		}
-	})
+	makeRes := func(notifications []*gnmiproto.Notification) *ggnmi.GetRes {
+		return &ggnmi.GetRes{Notifications: notifications}
+	}
+	makeUpdate := func(val *gnmiproto.TypedValue) *gnmiproto.Update {
+		return &gnmiproto.Update{Val: val}
+	}
+	makeTypedValue := func(json string) *gnmiproto.TypedValue {
+		return &gnmiproto.TypedValue{Value: &gnmiproto.TypedValue_JsonIetfVal{JsonIetfVal: []byte(json)}}
+	}
 
-	// Note: We can't easily construct gnmi.GetRes objects without internal types,
-	// so we test the nil case which is the most critical
+	tests := []struct {
+		name     string
+		res      *ggnmi.GetRes
+		expected bool
+	}{
+		{
+			name:     "nil pointer",
+			res:      nil,
+			expected: true,
+		},
+		{
+			name:     "zero notifications",
+			res:      makeRes(nil),
+			expected: true,
+		},
+		{
+			name:     "notification with zero updates",
+			res:      makeRes([]*gnmiproto.Notification{{}}),
+			expected: true,
+		},
+		{
+			name:     "nil val means bare node is present",
+			res:      makeRes([]*gnmiproto.Notification{{Update: []*gnmiproto.Update{makeUpdate(nil)}}}),
+			expected: false,
+		},
+		{
+			name:     "update with empty JSON object",
+			res:      makeRes([]*gnmiproto.Notification{{Update: []*gnmiproto.Update{makeUpdate(makeTypedValue("{}"))}}}),
+			expected: true,
+		},
+		{
+			name:     "update with empty JSON array",
+			res:      makeRes([]*gnmiproto.Notification{{Update: []*gnmiproto.Update{makeUpdate(makeTypedValue("[]"))}}}),
+			expected: true,
+		},
+		{
+			name:     "update with empty string val",
+			res:      makeRes([]*gnmiproto.Notification{{Update: []*gnmiproto.Update{makeUpdate(makeTypedValue(""))}}}),
+			expected: true,
+		},
+		{
+			name:     "update with real content",
+			res:      makeRes([]*gnmiproto.Notification{{Update: []*gnmiproto.Update{makeUpdate(makeTypedValue(`{"hostname":"router1"}`))}}}),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsGnmiGetResponseEmpty(tt.res)
+			if result != tt.expected {
+				t.Errorf("IsGnmiGetResponseEmpty() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
 }
 
 // TestEnsureGnmiConnection tests error handling

--- a/internal/provider/helpers/netconf.go
+++ b/internal/provider/helpers/netconf.go
@@ -365,6 +365,9 @@ func GetConfigWithTimeout(ctx context.Context, client *netconf.Client, source st
 
 // IsGetConfigResponseEmpty checks if a GetConfig response has an empty <data> element.
 func IsGetConfigResponseEmpty(res *netconf.Res) bool {
+	if res == nil {
+		return true
+	}
 	dataResult := res.Res.Get("data")
 	if !dataResult.Exists() {
 		return true

--- a/internal/provider/helpers/netconf_test.go
+++ b/internal/provider/helpers/netconf_test.go
@@ -2,11 +2,13 @@ package helpers
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/netascode/go-netconf"
+	"github.com/netascode/xmldot"
 )
 
 // ============================================================================
@@ -43,25 +45,19 @@ func TestAcquireNetconfLock(t *testing.T) {
 		expectLock      bool
 	}{
 		{
-			name:            "no reuse - should lock all operations",
+			name:            "no reuse locks regardless of operation type",
 			reuseConnection: false,
 			isWrite:         false,
 			expectLock:      true,
 		},
 		{
-			name:            "no reuse - write operation - should lock",
-			reuseConnection: false,
-			isWrite:         true,
-			expectLock:      true,
-		},
-		{
-			name:            "reuse - write operation - should lock",
+			name:            "reuse write locks",
 			reuseConnection: true,
 			isWrite:         true,
 			expectLock:      true,
 		},
 		{
-			name:            "reuse - read operation - should NOT lock",
+			name:            "reuse read does not lock",
 			reuseConnection: true,
 			isWrite:         false,
 			expectLock:      false,
@@ -77,12 +73,33 @@ func TestAcquireNetconfLock(t *testing.T) {
 				t.Errorf("AcquireNetconfLock() = %v, expected %v", acquired, tt.expectLock)
 			}
 
-			// If lock was acquired, unlock it
 			if acquired {
 				mutex.Unlock()
 			}
 		})
 	}
+
+	t.Run("no reuse blocks concurrent caller", func(t *testing.T) {
+		var mutex sync.Mutex
+		acquired := AcquireNetconfLock(&mutex, false, false)
+		if !acquired {
+			t.Fatal("first AcquireNetconfLock() should have acquired the lock")
+		}
+
+		// A second goroutine must not be able to acquire the lock while the first holds it.
+		done := make(chan bool, 1)
+		go func() {
+			// TryLock returns false when the mutex is already held.
+			done <- !mutex.TryLock()
+		}()
+		blocked := <-done
+
+		mutex.Unlock()
+
+		if !blocked {
+			t.Error("second caller should have been blocked while first held the lock")
+		}
+	})
 }
 
 func TestEnsureNetconfConnection(t *testing.T) {
@@ -141,10 +158,16 @@ func TestGetSubtreeFilter(t *testing.T) {
 			name:  "nested path",
 			xPath: "Cisco-IOS-XR-um-interface-cfg:/interfaces/interface/ipv4/address",
 			contains: []string{
+				"xmlns=",
+				"http://cisco.com/ns/yang/Cisco-IOS-XR-um-interface-cfg",
 				"<interfaces",
 				"<interface",
 				"<ipv4",
 				"<address",
+				"</address>",
+				"</ipv4>",
+				"</interface>",
+				"</interfaces>",
 			},
 		},
 	}
@@ -182,12 +205,12 @@ func TestIsGetConfigResponseEmpty(t *testing.T) {
 			expected: true,
 		},
 		{
-			name:     "empty data element - self-closing",
+			name:     "empty data element self-closing",
 			xmlStr:   `<rpc-reply><data/></rpc-reply>`,
 			expected: true,
 		},
 		{
-			name:     "empty data element - with closing tag",
+			name:     "empty data element with closing tag",
 			xmlStr:   `<rpc-reply><data></data></rpc-reply>`,
 			expected: true,
 		},
@@ -208,7 +231,7 @@ func TestIsGetConfigResponseEmpty(t *testing.T) {
 			var res *netconf.Res
 			if tt.xmlStr != "" {
 				res = &netconf.Res{}
-				res.Res.Raw = tt.xmlStr
+				res.Res = xmldot.Get(tt.xmlStr, "rpc-reply")
 			}
 
 			result := IsGetConfigResponseEmpty(res)
@@ -223,24 +246,68 @@ func TestIsGetConfigResponseEmpty(t *testing.T) {
 // NETCONF Body Manipulation Tests
 // ============================================================================
 
+// xmlGet is a test helper that queries a path in an XML string using xmldot.
+func xmlGet(xml, path string) string {
+	return xmldot.Get(xml, path).String()
+}
+
 func TestSetFromXPath(t *testing.T) {
 	tests := []struct {
-		name       string
-		xPath      string
-		value      interface{}
-		wantString string
+		name        string
+		xPath       string
+		value       interface{}
+		checkPath   string // xmldot path to verify the value was placed correctly
+		checkVal    string
+		extraChecks map[string]string // additional path→value assertions
 	}{
 		{
-			name:       "simple xpath with value",
-			xPath:      "Cisco-IOS-XR-um-hostname-cfg:/hostname/host-name",
-			value:      "test-router",
-			wantString: "test-router",
+			name:      "set value on leaf element",
+			xPath:     "Cisco-IOS-XR-um-hostname-cfg:/hostname/host-name",
+			value:     "test-router",
+			checkPath: "hostname.host-name",
+			checkVal:  "test-router",
 		},
 		{
-			name:       "xpath with namespace prefix",
-			xPath:      "Cisco-IOS-XR-um-hostname-cfg:/hostname",
-			value:      "",
-			wantString: "<hostname",
+			name:      "nested path with single key",
+			xPath:     "Cisco-IOS-XR-um-interface-cfg:/interfaces/interface[interface-name='GigabitEthernet0/0/0/0']/description",
+			value:     "uplink",
+			checkPath: "interfaces.interface.description",
+			checkVal:  "uplink",
+			extraChecks: map[string]string{
+				"interfaces.interface.interface-name": "GigabitEthernet0/0/0/0",
+			},
+		},
+		{
+			name:      "element with multiple predicates using and",
+			xPath:     "Cisco-IOS-XR-um-policymap-classmap-cfg:/policy-map/type/qos[policy-map-name='PM-QOS']/class[name='CM-HIGH' and type='qos']/priority/level",
+			value:     "1",
+			checkPath: "policy-map.type.qos.class.priority.level",
+			checkVal:  "1",
+			extraChecks: map[string]string{
+				"policy-map.type.qos.class.name": "CM-HIGH",
+				"policy-map.type.qos.class.type": "qos",
+			},
+		},
+		{
+			name:      "element with multiple separate predicates",
+			xPath:     "Cisco-IOS-XR-um-policymap-classmap-cfg:/policy-map/type/qos[policy-map-name='PM-QOS']/class[name='CM-HIGH'][type='qos']/priority/level",
+			value:     "1",
+			checkPath: "policy-map.type.qos.class.priority.level",
+			checkVal:  "1",
+			extraChecks: map[string]string{
+				"policy-map.type.qos.class.name": "CM-HIGH",
+				"policy-map.type.qos.class.type": "qos",
+			},
+		},
+		{
+			name:      "path with slash in predicate value",
+			xPath:     "Cisco-IOS-XR-um-interface-cfg:/interfaces/interface[interface-name='GigabitEthernet0/0/0/0']/mtu",
+			value:     "9000",
+			checkPath: "interfaces.interface.mtu",
+			checkVal:  "9000",
+			extraChecks: map[string]string{
+				"interfaces.interface.interface-name": "GigabitEthernet0/0/0/0",
+			},
 		},
 	}
 
@@ -250,16 +317,50 @@ func TestSetFromXPath(t *testing.T) {
 			result := SetFromXPath(body, tt.xPath, tt.value)
 			resultXML := result.Res()
 
-			if !strings.Contains(resultXML, tt.wantString) {
-				t.Errorf("SetFromXPath() should contain %q, got: %s", tt.wantString, resultXML)
+			got := xmlGet(resultXML, tt.checkPath)
+			if got != tt.checkVal {
+				t.Errorf("SetFromXPath() value at %q = %q, expected %q\nXML: %s",
+					tt.checkPath, got, tt.checkVal, resultXML)
+			}
+
+			for path, want := range tt.extraChecks {
+				if v := xmlGet(resultXML, path); v != want {
+					t.Errorf("SetFromXPath() extra check at %q = %q, expected %q\nXML: %s",
+						path, v, want, resultXML)
+				}
 			}
 		})
 	}
 }
 
-// TestSetFromXPathMultipleListEntries verifies that calling SetFromXPath with
-// different key predicates on the same list element creates separate XML elements
-// instead of overwriting the first one.
+// TestSetFromXPathPresenceContainer verifies that an empty value creates the element
+// rather than silently producing an empty body.
+func TestSetFromXPathPresenceContainer(t *testing.T) {
+	body := netconf.NewBody("")
+	result := SetFromXPath(body, "Cisco-IOS-XR-um-hostname-cfg:/hostname", "")
+	resultXML := result.Res()
+
+	if !xmldot.Get(resultXML, "hostname").Exists() {
+		t.Errorf("SetFromXPath() with empty value should create <hostname> element, got empty body\nXML: %q", resultXML)
+	}
+}
+
+// TestSetFromXPathNoDuplicateElements verifies that setting a value does not produce
+// both an empty placeholder element and a valued element at the same path.
+func TestSetFromXPathNoDuplicateElements(t *testing.T) {
+	body := netconf.NewBody("")
+	body = SetFromXPath(body, "Cisco-IOS-XR-um-hostname-cfg:/hostname/host-name", "router1")
+	xml := body.Res()
+
+	// Count occurrences of <host-name — there must be exactly one
+	count := strings.Count(xml, "<host-name")
+	if count != 1 {
+		t.Errorf("SetFromXPath() produced %d <host-name elements, expected exactly 1\nXML: %s", count, xml)
+	}
+}
+
+// TestSetFromXPathMultipleListEntries verifies that different key predicates on the
+// same list element produce separate sibling entries, not nested or overwritten ones.
 func TestSetFromXPathMultipleListEntries(t *testing.T) {
 	body := netconf.NewBody("")
 
@@ -276,33 +377,85 @@ func TestSetFromXPathMultipleListEntries(t *testing.T) {
 
 	xml := body.Res()
 
-	if !strings.Contains(xml, "CM-HIGH-PRIORITY") {
-		t.Errorf("Expected CM-HIGH-PRIORITY in XML, got: %s", xml)
+	// Find which array index each class landed in, then verify its priority is correct.
+	// This catches bugs where values from one class entry bleed into the other.
+	var highIdx, realIdx int = -1, -1
+	for i := 0; i < 4; i++ {
+		name := xmldot.Get(xml, fmt.Sprintf("policy-map.type.qos.class.%d.name", i)).String()
+		switch name {
+		case "CM-HIGH-PRIORITY":
+			highIdx = i
+		case "CM-REAL-TIME":
+			realIdx = i
+		}
 	}
-	if !strings.Contains(xml, "CM-REAL-TIME") {
-		t.Errorf("Expected CM-REAL-TIME in XML, got: %s", xml)
+
+	if highIdx == -1 {
+		t.Fatalf("CM-HIGH-PRIORITY class entry not found in XML: %s", xml)
 	}
-	if !strings.Contains(xml, ">2<") {
-		t.Errorf("Expected priority level 2 in XML, got: %s", xml)
+	if realIdx == -1 {
+		t.Fatalf("CM-REAL-TIME class entry not found in XML: %s", xml)
 	}
-	if !strings.Contains(xml, ">3<") {
-		t.Errorf("Expected priority level 3 in XML, got: %s", xml)
+
+	highLevel := xmldot.Get(xml, fmt.Sprintf("policy-map.type.qos.class.%d.priority.level", highIdx)).String()
+	realLevel := xmldot.Get(xml, fmt.Sprintf("policy-map.type.qos.class.%d.priority.level", realIdx)).String()
+
+	if highLevel != "2" {
+		t.Errorf("CM-HIGH-PRIORITY priority level = %q, expected \"2\"\nXML: %s", highLevel, xml)
+	}
+	if realLevel != "3" {
+		t.Errorf("CM-REAL-TIME priority level = %q, expected \"3\"\nXML: %s", realLevel, xml)
+	}
+}
+
+// TestSetFromXPathThenAppendSiblings verifies that AppendFromXPath after SetFromXPath
+// on the same parent path produces sibling elements, not nested ones.
+func TestSetFromXPathThenAppendSiblings(t *testing.T) {
+	body := netconf.NewBody("")
+	base := "Cisco-IOS-XR-um-interface-cfg:/interfaces/interface[interface-name='Bundle-Ether1']"
+
+	body = SetFromXPath(body, base+"/bundle/id", "1")
+	body = AppendFromXPath(body, base+"/bundle/load-balancing/hash", "src-ip")
+
+	xml := body.Res()
+
+	// id and hash must both be present; id must not be nested inside hash or vice versa
+	id := xmlGet(xml, "interfaces.interface.bundle.id")
+	hash := xmlGet(xml, "interfaces.interface.bundle.load-balancing.hash")
+
+	if id != "1" {
+		t.Errorf("bundle/id = %q, expected \"1\"\nXML: %s", id, xml)
+	}
+	if hash != "src-ip" {
+		t.Errorf("bundle/load-balancing/hash = %q, expected \"src-ip\"\nXML: %s", hash, xml)
 	}
 }
 
 func TestRemoveFromXPath(t *testing.T) {
 	tests := []struct {
-		name     string
-		xPath    string
-		contains []string
+		name          string
+		xPath         string
+		operationPath string // xmldot path where @nc:operation must equal "remove"
 	}{
 		{
-			name:  "remove operation with namespace",
-			xPath: "Cisco-IOS-XR-um-hostname-cfg:/hostname",
-			contains: []string{
-				"nc:operation=\"remove\"",
-				"xmlns:nc=",
-			},
+			name:          "path without predicates",
+			xPath:         "Cisco-IOS-XR-um-hostname-cfg:/hostname",
+			operationPath: "hostname.@nc:operation",
+		},
+		{
+			name:          "simple single element with key",
+			xPath:         "Cisco-IOS-XR-um-interface-cfg:/interfaces/interface[interface-name='GigabitEthernet0/0/0/0']",
+			operationPath: "interfaces.interface.@nc:operation",
+		},
+		{
+			name:          "nested path with single key",
+			xPath:         "Cisco-IOS-XR-um-interface-cfg:/interfaces/interface[interface-name='GigabitEthernet0/0/0/0']/description",
+			operationPath: "interfaces.interface.description.@nc:operation",
+		},
+		{
+			name:          "interface with slashes in name",
+			xPath:         "Cisco-IOS-XR-um-interface-cfg:/interfaces/interface[interface-name='GigabitEthernet0/0/0/0']/mtu",
+			operationPath: "interfaces.interface.mtu.@nc:operation",
 		},
 	}
 
@@ -312,10 +465,153 @@ func TestRemoveFromXPath(t *testing.T) {
 			result := RemoveFromXPath(body, tt.xPath)
 			resultXML := result.Res()
 
-			for _, substr := range tt.contains {
-				if !strings.Contains(resultXML, substr) {
-					t.Errorf("RemoveFromXPath() should contain %q, got: %s", substr, resultXML)
+			// nc namespace must be declared
+			if !strings.Contains(resultXML, "xmlns:nc=") {
+				t.Errorf("RemoveFromXPath() missing xmlns:nc declaration\nXML: %s", resultXML)
+			}
+
+			// operation="remove" must be on the exact target element
+			op := xmlGet(resultXML, tt.operationPath)
+			if op != "remove" {
+				t.Errorf("RemoveFromXPath() @nc:operation at %q = %q, expected \"remove\"\nXML: %s",
+					tt.operationPath, op, resultXML)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// AppendFromXPath Tests
+// ============================================================================
+
+func TestAppendFromXPath(t *testing.T) {
+	t.Run("sequential appends produce sibling elements in order", func(t *testing.T) {
+		body := netconf.NewBody("")
+		base := "Cisco-IOS-XR-um-route-policy-cfg:/routing-policy/route-policies/route-policy[route-policy-name='RP-IN']/rpl-route-policy"
+		body = AppendFromXPath(body, base, "value-a")
+		body = AppendFromXPath(body, base, "value-b")
+		body = AppendFromXPath(body, base, "value-c")
+		xml := body.Res()
+
+		want := []string{"value-a", "value-b", "value-c"}
+		for i, w := range want {
+			got := xmldot.Get(xml, fmt.Sprintf("routing-policy.route-policies.route-policy.rpl-route-policy.%d", i)).String()
+			if got != w {
+				t.Errorf("AppendFromXPath() entry[%d] = %q, expected %q\nXML: %s", i, got, w, xml)
+			}
+		}
+	})
+
+	t.Run("empty value creates presence container", func(t *testing.T) {
+		body := netconf.NewBody("")
+		body = AppendFromXPath(body, "Cisco-IOS-XR-um-interface-cfg:/interfaces/interface[interface-name='Loopback0']/ipv4/addresses/address", "")
+		xml := body.Res()
+
+		if !strings.Contains(xml, "<address") {
+			t.Errorf("AppendFromXPath() with empty value should create <address> element\nXML: %s", xml)
+		}
+	})
+
+	t.Run("namespace declared on root element when module prefix present", func(t *testing.T) {
+		// augmentNamespaces runs only when value is non-empty; verify xmlns is added.
+		body := netconf.NewBody("")
+		body = AppendFromXPath(body,
+			"Cisco-IOS-XR-um-route-policy-cfg:/routing-policy/route-policies/route-policy[route-policy-name='RP-TEST']/rpl-route-policy",
+			"permit 10\n")
+		xml := body.Res()
+
+		if !strings.Contains(xml, "xmlns") {
+			t.Errorf("AppendFromXPath() should declare xmlns on namespaced root element\nXML: %s", xml)
+		}
+		if !strings.Contains(xml, "Cisco-IOS-XR-um-route-policy-cfg") {
+			t.Errorf("AppendFromXPath() xmlns should reference the module namespace\nXML: %s", xml)
+		}
+	})
+}
+
+// ============================================================================
+// GetFromXPath Tests
+// ============================================================================
+
+func TestGetFromXPath(t *testing.T) {
+	// Build a representative IOS-XR XML response to query against
+	const sampleXML = `<rpc-reply>
+		<data>
+			<interfaces xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-um-interface-cfg">
+				<interface>
+					<interface-name>GigabitEthernet0/0/0/0</interface-name>
+					<description>uplink-primary</description>
+					<mtu>9000</mtu>
+				</interface>
+				<interface>
+					<interface-name>GigabitEthernet0/0/0/1</interface-name>
+					<description>uplink-secondary</description>
+					<mtu>1500</mtu>
+				</interface>
+			</interfaces>
+			<hostname xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-um-hostname-cfg">
+				<host-name>router1</host-name>
+			</hostname>
+		</data>
+	</rpc-reply>`
+
+	parsed := xmldot.Get(sampleXML, "rpc-reply.data")
+
+	tests := []struct {
+		name      string
+		xPath     string
+		wantVal   string
+		wantEmpty bool
+	}{
+		{
+			name:    "simple path without predicates",
+			xPath:   "Cisco-IOS-XR-um-hostname-cfg:/hostname/host-name",
+			wantVal: "router1",
+		},
+		{
+			name:    "filter by key returns first match",
+			xPath:   "Cisco-IOS-XR-um-interface-cfg:/interfaces/interface[interface-name='GigabitEthernet0/0/0/0']/description",
+			wantVal: "uplink-primary",
+		},
+		{
+			name:    "filter correctly returns second match",
+			xPath:   "Cisco-IOS-XR-um-interface-cfg:/interfaces/interface[interface-name='GigabitEthernet0/0/0/1']/description",
+			wantVal: "uplink-secondary",
+		},
+		{
+			name:    "path with value containing slashes",
+			xPath:   "Cisco-IOS-XR-um-interface-cfg:/interfaces/interface[interface-name='GigabitEthernet0/0/0/0']/mtu",
+			wantVal: "9000",
+		},
+		{
+			name:      "non-existent path",
+			xPath:     "Cisco-IOS-XR-um-interface-cfg:/interfaces/interface[interface-name='GigabitEthernet0/0/0/0']/ipv4",
+			wantEmpty: true,
+		},
+		{
+			name:      "filter with no matching key",
+			xPath:     "Cisco-IOS-XR-um-interface-cfg:/interfaces/interface[interface-name='GigabitEthernet9/9/9/9']/description",
+			wantEmpty: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetFromXPath(parsed, tt.xPath)
+
+			if tt.wantEmpty {
+				if result.Exists() {
+					t.Errorf("GetFromXPath(%q) expected empty result, got: %q", tt.xPath, result.String())
 				}
+				return
+			}
+
+			if !result.Exists() {
+				t.Errorf("GetFromXPath(%q) returned no result, expected %q", tt.xPath, tt.wantVal)
+				return
+			}
+			if got := result.String(); got != tt.wantVal {
+				t.Errorf("GetFromXPath(%q) = %q, expected %q", tt.xPath, got, tt.wantVal)
 			}
 		})
 	}

--- a/internal/provider/helpers/utils_test.go
+++ b/internal/provider/helpers/utils_test.go
@@ -1,0 +1,257 @@
+package helpers
+
+import (
+	"testing"
+)
+
+// ============================================================================
+// IsListPath Tests
+// ============================================================================
+
+func TestIsListPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		xPath    string
+		expected bool
+	}{
+		{
+			name:     "list with simple predicate",
+			xPath:    "/interfaces/interface[interface-name='GigabitEthernet0/0/0/0']",
+			expected: true,
+		},
+		{
+			name:     "list with quoted predicate",
+			xPath:    `/interfaces/interface[interface-name="GigabitEthernet0/0/0/0"]`,
+			expected: true,
+		},
+		{
+			name:     "list with multiple predicates using and",
+			xPath:    "/policy-map/class[name='CM-HIGH' and type='qos']",
+			expected: true,
+		},
+		{
+			name:     "list with multiple separate predicates",
+			xPath:    "/policy-map/class[name='CM-HIGH'][type='qos']",
+			expected: true,
+		},
+		{
+			name:     "container without predicate",
+			xPath:    "/interfaces/interface/ipv4",
+			expected: false,
+		},
+		{
+			name:     "simple single segment",
+			xPath:    "/hostname",
+			expected: false,
+		},
+		{
+			name:     "predicate in middle segment but not at end",
+			xPath:    "/interfaces/interface[interface-name='Gi0/0/0/0']/ipv4/address",
+			expected: false,
+		},
+		{
+			name:     "empty path",
+			xPath:    "",
+			expected: false,
+		},
+		{
+			name:     "list path with trailing whitespace",
+			xPath:    "/interfaces/interface[interface-name='Gi0/0/0/0']   ",
+			expected: true,
+		},
+		{
+			name:     "container path with trailing whitespace",
+			xPath:    "/interfaces/interface   ",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsListPath(tt.xPath)
+			if result != tt.expected {
+				t.Errorf("IsListPath(%q) = %v, expected %v", tt.xPath, result, tt.expected)
+			}
+		})
+	}
+}
+
+// ============================================================================
+// ParseXPathSegment Tests
+// ============================================================================
+
+func TestParseXPathSegment(t *testing.T) {
+	tests := []struct {
+		name         string
+		segment      string
+		wantElement  string
+		wantKeyCount int
+		wantKeys     []KeyValue
+	}{
+		{
+			name:         "simple element without predicates",
+			segment:      "interface",
+			wantElement:  "interface",
+			wantKeyCount: 0,
+		},
+		{
+			name:         "element with single predicate single quotes",
+			segment:      "interface[interface-name='GigabitEthernet0/0/0/0']",
+			wantElement:  "interface",
+			wantKeyCount: 1,
+			wantKeys:     []KeyValue{{Key: "interface-name", Value: "GigabitEthernet0/0/0/0"}},
+		},
+		{
+			name:         "element with single predicate double quotes",
+			segment:      `interface[interface-name="GigabitEthernet0/0/0/0"]`,
+			wantElement:  "interface",
+			wantKeyCount: 1,
+			wantKeys:     []KeyValue{{Key: "interface-name", Value: "GigabitEthernet0/0/0/0"}},
+		},
+		{
+			name:         "element with multiple predicates using and",
+			segment:      "class[name='CM-HIGH' and type='qos']",
+			wantElement:  "class",
+			wantKeyCount: 2,
+			wantKeys: []KeyValue{
+				{Key: "name", Value: "CM-HIGH"},
+				{Key: "type", Value: "qos"},
+			},
+		},
+		{
+			name:         "element with multiple separate predicates",
+			segment:      "class[name='CM-HIGH'][type='qos']",
+			wantElement:  "class",
+			wantKeyCount: 2,
+			wantKeys: []KeyValue{
+				{Key: "name", Value: "CM-HIGH"},
+				{Key: "type", Value: "qos"},
+			},
+		},
+		{
+			name:         "element with three predicates using and",
+			segment:      "route[vrf='default' and dst='10.0.0.0' and prefix='24']",
+			wantElement:  "route",
+			wantKeyCount: 3,
+			wantKeys: []KeyValue{
+				{Key: "vrf", Value: "default"},
+				{Key: "dst", Value: "10.0.0.0"},
+				{Key: "prefix", Value: "24"},
+			},
+		},
+		{
+			name:         "element with numeric key value",
+			segment:      "vlan[id='100']",
+			wantElement:  "vlan",
+			wantKeyCount: 1,
+			wantKeys:     []KeyValue{{Key: "id", Value: "100"}},
+		},
+		{
+			name:         "element with dot in predicate value",
+			segment:      "interface[interface-name='Bundle-Ether10.666']",
+			wantElement:  "interface",
+			wantKeyCount: 1,
+			wantKeys:     []KeyValue{{Key: "interface-name", Value: "Bundle-Ether10.666"}},
+		},
+		{
+			name:         "element name with hyphen",
+			segment:      "interface-configuration[active='act'][interface-name='Gi0/0/0/0']",
+			wantElement:  "interface-configuration",
+			wantKeyCount: 2,
+		},
+		{
+			name:         "element with namespace prefix",
+			segment:      "Cisco-IOS-XR-um-hostname-cfg:hostname",
+			wantElement:  "Cisco-IOS-XR-um-hostname-cfg:hostname",
+			wantKeyCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			element, keys := ParseXPathSegment(tt.segment)
+
+			if element != tt.wantElement {
+				t.Errorf("ParseXPathSegment(%q) element = %q, expected %q", tt.segment, element, tt.wantElement)
+			}
+			if len(keys) != tt.wantKeyCount {
+				t.Errorf("ParseXPathSegment(%q) key count = %d, expected %d (keys: %v)",
+					tt.segment, len(keys), tt.wantKeyCount, keys)
+			}
+			for i, kv := range tt.wantKeys {
+				if i >= len(keys) {
+					break
+				}
+				if keys[i].Key != kv.Key || keys[i].Value != kv.Value {
+					t.Errorf("ParseXPathSegment(%q) key[%d] = {%q, %q}, expected {%q, %q}",
+						tt.segment, i, keys[i].Key, keys[i].Value, kv.Key, kv.Value)
+				}
+			}
+		})
+	}
+}
+
+// ============================================================================
+// SplitXPathSegments Tests
+// ============================================================================
+
+func TestSplitXPathSegments(t *testing.T) {
+	tests := []struct {
+		name     string
+		xPath    string
+		expected []string
+	}{
+		{
+			name:     "simple path",
+			xPath:    "interfaces/interface/ipv4",
+			expected: []string{"interfaces", "interface", "ipv4"},
+		},
+		{
+			name:     "path with single predicate",
+			xPath:    "interfaces/interface[interface-name='Gi0/0/0/0']/description",
+			expected: []string{"interfaces", "interface[interface-name='Gi0/0/0/0']", "description"},
+		},
+		{
+			name:     "path with slash in predicate value",
+			xPath:    "interfaces/interface[interface-name='GigabitEthernet0/0/0/0']/mtu",
+			expected: []string{"interfaces", "interface[interface-name='GigabitEthernet0/0/0/0']", "mtu"},
+		},
+		{
+			name:     "path with composite key using and",
+			xPath:    "policy-map/class[name='CM-HIGH' and type='qos']/priority/level",
+			expected: []string{"policy-map", "class[name='CM-HIGH' and type='qos']", "priority", "level"},
+		},
+		{
+			name:     "path with multiple separate predicates",
+			xPath:    "policy-map/class[name='CM-HIGH'][type='qos']/priority",
+			expected: []string{"policy-map", "class[name='CM-HIGH'][type='qos']", "priority"},
+		},
+		{
+			name:     "single segment",
+			xPath:    "hostname",
+			expected: []string{"hostname"},
+		},
+		{
+			name:     "empty path",
+			xPath:    "",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SplitXPathSegments(tt.xPath)
+			if len(result) != len(tt.expected) {
+				t.Errorf("SplitXPathSegments(%q) returned %d segments, expected %d\ngot: %v\nwant: %v",
+					tt.xPath, len(result), len(tt.expected), result, tt.expected)
+				return
+			}
+			for i, seg := range tt.expected {
+				if result[i] != seg {
+					t.Errorf("SplitXPathSegments(%q) segment[%d] = %q, expected %q",
+						tt.xPath, i, result[i], seg)
+				}
+			}
+		})
+	}
+}

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -7,7 +7,7 @@ description: |-
 
 # Changelog
 
-## 0.7.2
+## Unreleased
 
 - Add `contexts`, `context_mappings` lists to `iosxr_snmp_server` resource and data source
 - Fix: Make `auto_cost_reference_bandwidth` optional in `router_isis` resource and data source


### PR DESCRIPTION
## Summary

- Fix nil pointer panic in `IsGetConfigResponseEmpty` by adding a nil guard
- Add `utils_test.go` covering `IsListPath`, `ParseXPathSegment`, and `SplitXPathSegments`
- Expand `TestIsGnmiGetResponseEmpty` to cover all response branches (nil, empty, bare node, real content)
- Rewrite `TestSetFromXPath` with precise xmldot path assertions instead of string contains
- Add `TestSetFromXPathPresenceContainer`, `TestSetFromXPathNoDuplicateElements`, `TestSetFromXPathMultipleListEntries`, `TestSetFromXPathThenAppendSiblings`
- Rewrite `TestRemoveFromXPath` to assert `@nc:operation="remove"` at the exact target element
- Add `TestAppendFromXPath` and `TestGetFromXPath`
- Add concurrency tests for `AcquireGnmiLock` and `AcquireNetconfLock` using `mutex.TryLock()`

## Test plan

- [x] `go test ./internal/provider/helpers/... -v` passes with all sub-cases green
- [x] No regressions in existing tests
